### PR TITLE
added viewport meta block to pageheader

### DIFF
--- a/src/site/_includes/components/pageheader.njk
+++ b/src/site/_includes/components/pageheader.njk
@@ -1,3 +1,4 @@
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
 <script src="https://unpkg.com/mermaid/dist/mermaid.min.js"></script>
 <script>
     mermaid.initialize({


### PR DESCRIPTION
I was struggling to properly style for mobile browsers and discovered that the viewport wasn't set. This was making setting width and relative font properties very difficult. Adding the viewport makes it much easier. 