### PR TITLE
fix(jsonify): default to empty string on empty content

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -197,7 +197,7 @@ module.exports = function(eleventyConfig) {
     eleventyConfig.addPlugin(faviconPlugin, { destination: 'dist' });
     eleventyConfig.addPlugin(tocPlugin, {ul:true, tags: ['h1','h2', 'h3', 'h4', 'h5', 'h6']});
     eleventyConfig.addFilter('jsonify', function (variable) {
-      return JSON.stringify(variable);
+      return JSON.stringify(variable) || '""';
     });
 
     return {


### PR DESCRIPTION
empty files cause syntax errors, because there is no empty data given after the JSON entry