### PR TITLE
Hide dataview variable

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -195,22 +195,15 @@ module.exports = function (eleventyConfig) {
   eleventyConfig.addFilter("taggify", function (str) {
     return (
       str &&
-      str.replace(
-        tagRegex,
-        function (match, precede, tag) {
-          return `${precede}<a class="tag" onclick="toggleTagSearch(this)">${tag}</a>`;
-        }
-      )
+      str.replace(tagRegex, function (match, precede, tag) {
+        return `${precede}<a class="tag" onclick="toggleTagSearch(this)">${tag}</a>`;
+      })
     );
   });
 
   eleventyConfig.addFilter("searchableTags", function (str) {
     let tags;
-    let match =
-      str &&
-      str.match(
-        tagRegex,
-      );
+    let match = str && str.match(tagRegex);
     if (match) {
       tags = match
         .map((m) => {
@@ -223,6 +216,15 @@ module.exports = function (eleventyConfig) {
     } else {
       return "";
     }
+  });
+
+  eleventyConfig.addFilter("hideDataview", function (str) {
+    return (
+      str &&
+      str.replace(/\(\S+\:\:(.*)\)/g, function (_, value) {
+        return value.trim();
+      })
+    );
   });
 
   eleventyConfig.addTransform("callout-block", function (str) {
@@ -289,11 +291,11 @@ module.exports = function (eleventyConfig) {
     return JSON.stringify(variable) || '""';
   });
 
-  eleventyConfig.addFilter('validJson', function (variable) {
-    if(Array.isArray((variable))){
-        return variable.map(x=>x.replaceAll("\\", "\\\\")).join(",");
-  }else if(typeof(variable) === 'string'){
-        return variable.replaceAll("\\", "\\\\"); 
+  eleventyConfig.addFilter("validJson", function (variable) {
+    if (Array.isArray(variable)) {
+      return variable.map((x) => x.replaceAll("\\", "\\\\")).join(",");
+    } else if (typeof variable === "string") {
+      return variable.replaceAll("\\", "\\\\");
     }
     return variable;
   });

--- a/src/site/_includes/layouts/note.njk
+++ b/src/site/_includes/layouts/note.njk
@@ -39,7 +39,7 @@ permalink: "notes/{{ page.fileSlug | slugify }}/"
           {% endif %}
         </div>
       </header>
-      {{ content | hideDataView | link | taggify | highlight | safe}}
+      {{ content | hideDataview | link | taggify | highlight | safe}}
     </main>
 
     {% if settings.dgShowBacklinks === true or settings.dgShowLocalGraph === true or settings.dgShowToc === true%}

--- a/src/site/_includes/layouts/note.njk
+++ b/src/site/_includes/layouts/note.njk
@@ -37,7 +37,7 @@ permalink: "notes/{{ page.fileSlug | slugify }}/"
           </div>
         {% endif %}
       </div>
-      {{ content | link | taggify | highlight | safe}}
+      {{ content | hideDataView | link | taggify | highlight | safe}}
     </div>
 
     {% if settings.dgShowBacklinks === true or settings.dgShowLocalGraph === true or settings.dgShowToc === true%}

--- a/src/site/index.njk
+++ b/src/site/index.njk
@@ -35,7 +35,7 @@
       </div>
 
       {%- for garden in collections.gardenEntry -%}
-        {{garden.templateContent | link | taggify | highlight | safe }}
+        {{garden.templateContent | hideDataview | link | taggify | highlight | safe }}
       {%- endfor -%}
     </div>
 


### PR DESCRIPTION
According to [DataView docs](https://blacksmithgu.github.io/obsidian-dataview/annotation/add-metadata/#inline-fields), users should be able to add DataView value with hidden keys with the following format:

```md
This will not show the (longKeyIDontNeedWhenReading:: key).
```

Which will show as the following in the Reader Mode:

```md
This will not show the key.
```

This PR implements just that for the notes published.