### PR TITLE
Dynamic import implementation

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -11,6 +11,9 @@ const { headerToId, namedHeadingsFilter } = require("./src/helpers/utils");
 const tagRegex = /(^|\s|\>)(#[^\s!@#$%^&*()=+\.,\[{\]};:'"?><]+)(?!([^<]*>))/g;
 
 module.exports = function (eleventyConfig) {
+  eleventyConfig.setLiquidOptions({
+    dynamicPartials: true,
+  });
   let markdownLib = markdownIt({
     breaks: true,
     html: true,

--- a/src/site/_data/dynamics.js
+++ b/src/site/_data/dynamics.js
@@ -24,7 +24,7 @@ const generateComponentPaths = async (namespace) => {
 const generateStylesPaths = async () => {
     try {
         const tree = await fsFileTree(`${STYLE_PATH}`);
-        let comps = Object.keys(tree).map((p) => `/styles/user/${p}`);
+        let comps = Object.keys(tree).map((p) => `/styles/user/${p}`.replace('.scss', '.css'));
         comps.sort()
         return comps
     } catch {

--- a/src/site/_data/dynamics.js
+++ b/src/site/_data/dynamics.js
@@ -1,0 +1,33 @@
+const fsFileTree = require("fs-file-tree");
+
+const BASE_PATH = "src/site/_includes/components/user"
+const NAMESPACES = ["index", "notes", "common"];
+const SLOTS = ["header", "afterContent", "footer"]
+
+const generateComponentPaths = async (namespace) => {
+    const data = {};
+    for (let index = 0; index < SLOTS.length; index++) {
+        const slot = SLOTS[index];
+        try {
+            console.log(`${BASE_PATH}/${namespace}/${slot}`);
+            const tree = await fsFileTree(`${BASE_PATH}/${namespace}/${slot}`);
+            let comps = Object.keys(tree).filter((p) => p.indexOf(".njk") != -1).map((p) => `components/user/${namespace}/${slot}/${p}`);
+            comps.sort()
+            data[slot] = comps;
+        } catch {
+            data[slot] = [];
+        }
+    }
+    return data;
+}
+
+
+module.exports = async () => {
+    const data = {};
+    for (let index = 0; index < NAMESPACES.length; index++) {
+        const ns = NAMESPACES[index];
+        data[ns] = await generateComponentPaths(ns);
+    }
+    console.log(data);
+    return data;
+}

--- a/src/site/_data/dynamics.js
+++ b/src/site/_data/dynamics.js
@@ -9,7 +9,6 @@ const generateComponentPaths = async (namespace) => {
     for (let index = 0; index < SLOTS.length; index++) {
         const slot = SLOTS[index];
         try {
-            console.log(`${BASE_PATH}/${namespace}/${slot}`);
             const tree = await fsFileTree(`${BASE_PATH}/${namespace}/${slot}`);
             let comps = Object.keys(tree).filter((p) => p.indexOf(".njk") != -1).map((p) => `components/user/${namespace}/${slot}/${p}`);
             comps.sort()
@@ -28,6 +27,5 @@ module.exports = async () => {
         const ns = NAMESPACES[index];
         data[ns] = await generateComponentPaths(ns);
     }
-    console.log(data);
     return data;
 }

--- a/src/site/_data/dynamics.js
+++ b/src/site/_data/dynamics.js
@@ -1,6 +1,7 @@
 const fsFileTree = require("fs-file-tree");
 
 const BASE_PATH = "src/site/_includes/components/user"
+const STYLE_PATH = "src/site/styles/user"
 const NAMESPACES = ["index", "notes", "common"];
 const SLOTS = ["header", "afterContent", "footer"]
 
@@ -20,6 +21,17 @@ const generateComponentPaths = async (namespace) => {
     return data;
 }
 
+const generateStylesPaths = async () => {
+    try {
+        const tree = await fsFileTree(`${STYLE_PATH}`);
+        let comps = Object.keys(tree).map((p) => `/styles/user/${p}`);
+        comps.sort()
+        return comps
+    } catch {
+        return [];
+    }
+}
+
 
 module.exports = async () => {
     const data = {};
@@ -27,5 +39,6 @@ module.exports = async () => {
         const ns = NAMESPACES[index];
         data[ns] = await generateComponentPaths(ns);
     }
+    data['styles'] = await generateStylesPaths()
     return data;
 }

--- a/src/site/_includes/components/pageheader.njk
+++ b/src/site/_includes/components/pageheader.njk
@@ -29,6 +29,9 @@
 {%endif%}
 
 <link href="/styles/custom-style.css" rel="stylesheet">
+{%- for style in dynamics.styles -%}
+<link href="{{style}}" rel="stylesheet">
+{%- endfor -%}
 
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/src/site/_includes/layouts/note.njk
+++ b/src/site/_includes/layouts/note.njk
@@ -38,8 +38,20 @@ permalink: "notes/{{ page.fileSlug | slugify }}/"
             </div>
           {% endif %}
         </div>
+      {% for imp in dynamics.common.header %}
+        {% include imp %}
+      {% endfor %}
+      {% for imp in dynamics.notes.header %}
+        {% include imp %}
+      {% endfor %}
       </header>
       {{ content | hideDataview | link | taggify | highlight | safe}}
+      {% for imp in dynamics.common.afterContent %}
+        {% include imp %}
+      {% endfor %}
+      {% for imp in dynamics.notes.afterContent %}
+        {% include imp %}
+      {% endfor %}
     </main>
 
     {% if settings.dgShowBacklinks === true or settings.dgShowLocalGraph === true or settings.dgShowToc === true%}
@@ -50,5 +62,11 @@ permalink: "notes/{{ page.fileSlug | slugify }}/"
       {%include "components/linkPreview.njk"%}
     {% endif %}
     {% include "components/references.njk" %}
+    {% for imp in dynamics.common.footer %}
+      {% include imp %}
+    {% endfor %}
+    {% for imp in dynamics.notes.footer %}
+      {% include imp %}
+    {% endfor %}
   </body>
 </html>

--- a/src/site/index.njk
+++ b/src/site/index.njk
@@ -33,10 +33,22 @@
           </div>
         {% endif %}
       </div>
+      {% for imp in dynamics.common.header %}
+        {% include imp %}
+      {% endfor %}
+      {% for imp in dynamics.index.header %}
+        {% include imp %}
+      {% endfor %}
       </header>
       {%- for garden in collections.gardenEntry -%}
         {{garden.templateContent | hideDataview | link | taggify | highlight | safe }}
       {%- endfor -%}
+      {% for imp in dynamics.common.afterContent %}
+        {% include imp %}
+      {% endfor %}
+      {% for imp in dynamics.index.afterContent %}
+        {% include imp %}
+      {% endfor %}
     </main>
 
     {% if settings.dgShowBacklinks === true or settings.dgShowLocalGraph === true or settings.dgShowToc === true%}
@@ -46,5 +58,11 @@
     {% if settings.dgLinkPreview === true %}
       {%include "components/linkPreview.njk"%}
     {% endif %}
+    {% for imp in dynamics.common.footer %}
+      {% include imp %}
+    {% endfor %}
+    {% for imp in dynamics.index.footer %}
+      {% include imp %}
+    {% endfor %}
     </body>
   </html>


### PR DESCRIPTION
This PR implements a Dynamic import of liquid components in various slots. It handles exceptions gracefully so that the site works if the necessary file structure is missing. This is a step toward better maintainability and merging from upstream.

### How does it works
#### Namespaces
These are the namespaces currently supported:

1. common
2. index
3. notes

#### Slots
These are the supported slots:

1. header
2. afterContent
3. footer

The files should be placed using the following format:

```
src/site/_includes/components/user/<namespace>/<slot>/<filename>.njk
```

### Examples
For example to add common content in every pages header right after the title and tags the file should be placed in the following directory:

```
src/site/_includes/components/user/common/header/
```

Or,

Say, you have a comment system implemented in a file (e.g. `comment.njk`) and you want to use that only in notes pages, put it in the following path:

```
src/site/_includes/components/user/notes/footer/comment.njk
```

### Dynamic CSS/SCSS

Any css/scss files placed under `src/site/styles/user` will automatically linked into the head right after the `custom-styles.scss`.

### Caution
Remember that, the paths for a given slot are always sorted by filename. Therefore, if order matters, you should name files such they maintain the alphabetical order.