### PR TITLE
CSS vars to control graph colors

### DIFF
--- a/src/site/_includes/components/graphScript.njk
+++ b/src/site/_includes/components/graphScript.njk
@@ -56,8 +56,8 @@
         height = el.offsetHeight;
         const highlightNodes = new Set();
         let hoverNode = null;
-        const color = getCssVar("--text-accent");
-        const mutedColor = getCssVar("--text-muted");
+        const color = getCssVar("--graph-main");
+        const mutedColor = getCssVar("--graph-muted");
 
         let Graph = ForceGraph()
         (el)

--- a/src/site/styles/digital-garden-base.scss
+++ b/src/site/styles/digital-garden-base.scss
@@ -9,6 +9,8 @@ body {
     --note-icon-2: url(/img/tree-2.svg);
     --note-icon-3: url(/img/tree-3.svg);
     --note-icon-fallback: url(/img/default-note-icon.svg);
+    --graph-main: var(--text-accent);
+    --graph-muted: var(--text-muted);
 }
 
 .content {

--- a/src/site/styles/style.scss
+++ b/src/site/styles/style.scss
@@ -20,6 +20,11 @@
     --callout-content-padding: 0;
 }
 
+body {
+    --graph-main: var(--text-accent);
+    --graph-muted: var(--text-muted);
+}
+
 h1 {
     color: #ffef60;
 }

--- a/src/site/styles/style.scss
+++ b/src/site/styles/style.scss
@@ -20,11 +20,6 @@
     --callout-content-padding: 0;
 }
 
-body {
-    --graph-main: var(--text-accent);
-    --graph-muted: var(--text-muted);
-}
-
 h1 {
     color: #ffef60;
 }


### PR DESCRIPTION
It adds to CSS vars so that the graph colours can be tweaked. Some themes' accents and muted colours are too close to make any noticeable differences.