### PR TITLE
Resolve collapsible nested callouts

### DIFF
--- a/src/site/_includes/components/calloutScript.njk
+++ b/src/site/_includes/components/calloutScript.njk
@@ -29,7 +29,7 @@
 
         // Collapse callouts
         Array.from(document.querySelectorAll(".callout.is-collapsible")).forEach((elem) => {
-            elem.addEventListener("click", (event) => {
+            elem.querySelector('.callout-title').addEventListener("click", (event) => {
                 if (elem.classList.contains("is-collapsed")) {
                     elem.classList.remove("is-collapsed");
                 } else {


### PR DESCRIPTION
**Previously**:
When there are nested collapsible callouts, if you want to open a child one, by clicking on it, the parent one will close. You would have to re-open the parent callout to see the now-open child one.

**Now**:
To open and close a collapsible callout, you have to click on the "callout-title" div; resolve the problem with nested one.
[Live Preview](https://voidblueprint.vercel.app/void-blueprint/physics/classic-physics/electro-magnetism/charge-conservation-law/)