### PR TITLE
Add new attribute to tags

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -203,7 +203,7 @@ module.exports = function (eleventyConfig) {
     return (
       str &&
       str.replace(tagRegex, function (match, precede, tag) {
-        return `${precede}<a class="tag" onclick="toggleTagSearch(this)">${tag}</a>`;
+        return `${precede}<a class="tag" onclick="toggleTagSearch(this)" data-content="${tag}">${tag}</a>`;
       })
     );
   });


### PR DESCRIPTION
Really small change to makes it easier to apply custom styles to specific tags with CSS.

As an example:
In Obsidian I use a small snipet to add color to some bits of text:
- **Editing**: ![image](https://user-images.githubusercontent.com/76615801/220070181-5bdbb1e8-3c76-4f55-a304-e05a982ec275.png)
- **Reading**: ![image](https://user-images.githubusercontent.com/76615801/220070259-8cdd1b5a-c918-40c8-99ad-5dd9da81f853.png)

I achive this using this css code:
```css
a[href^="#h-"]{
    display:none !important;  
}
a[href^="#h-a"] + em {
    color: rgb(0,255,255);
}
```
To make it also work here, all I need to do is add the small change I've made + this code in _customstyle.css_:
```css
a.tag[data-content^="#h"]{
    display: none !important;
}
a.tag[data-content^="#h-a"] + em {
    color: rgb(0,255,255) !important;
}
```
[Live Preview](https://voidblueprint.vercel.app/void-blueprint/test-page/)
