### PR TITLE
Make "title-only Callout" possible

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -279,7 +279,10 @@ module.exports = function (eleventyConfig) {
         blockquote.classList.add(isCollapsable ? "is-collapsible" : "");
         blockquote.classList.add(isCollapsed ? "is-collapsed" : "");
         blockquote.setAttribute("data-callout", calloutType.toLowerCase());
-        blockquote.innerHTML = `${titleDiv}\n<div class="callout-content">${content}</div>`;
+        const contentDiv = content.replace(/<[^>]*>|[\n\r\s]+/g, "")
+          ? `\n<div class="callout-content">${content}</div>`   
+          : "";
+        blockquote.innerHTML = `${titleDiv}${contentDiv}</div>`;
       }
     };
 


### PR DESCRIPTION
**Before**: 
If you have a "title-only Callout", a "callout-content" div would be created. Inside it, there would be a "p" tag, which could mess up its appearance.

**Now**: 
If there's nothing inside the callout, the corresponding callout won't be created, thus resolving the appearance issue. [Live Preview](https://voidblueprint.vercel.app/void-blueprint/test-page/)