### PR TITLE
feat: Allow users to put scripts in src/site/scripts folder

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -297,6 +297,7 @@ module.exports = function (eleventyConfig) {
   });
 
   eleventyConfig.addPassthroughCopy("src/site/img");
+  eleventyConfig.addPassthroughCopy("src/site/scripts");
   eleventyConfig.addPassthroughCopy("src/site/styles/_theme.*.css");
   eleventyConfig.addPlugin(faviconPlugin, { destination: "dist" });
   eleventyConfig.addPlugin(tocPlugin, {


### PR DESCRIPTION
Another step towards hackability. Users can add js in `src/site/scripts` to serve from the garden instead of CDN or remote sources.