### PR TITLE
Table wrapper for markdown tables

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -187,7 +187,10 @@ module.exports = function (eleventyConfig) {
           if (frontMatter.data.permalink) {
             permalink = frontMatter.data.permalink;
           }
-          if (frontMatter.data.tags && frontMatter.data.tags.indexOf("gardenEntry") != -1) {
+          if (
+            frontMatter.data.tags &&
+            frontMatter.data.tags.indexOf("gardenEntry") != -1
+          ) {
             permalink = "/";
           }
           if (frontMatter.data.noteIcon) {
@@ -254,7 +257,7 @@ module.exports = function (eleventyConfig) {
         let calloutType = "";
         let isCollapsable;
         let isCollapsed;
-        const calloutMeta = /\[!([\w-]*)\](\+|\-){0,1}(\s?.*)/;;
+        const calloutMeta = /\[!([\w-]*)\](\+|\-){0,1}(\s?.*)/;
         if (!content.match(calloutMeta)) {
           continue;
         }
@@ -293,6 +296,17 @@ module.exports = function (eleventyConfig) {
     return str && parsed.innerHTML;
   });
 
+  eleventyConfig.addTransform("table", function (str) {
+    const parsed = parse(str);
+    for (const t of parsed.querySelectorAll(".cm-s-obsidian > table")) {
+      let inner = t.innerHTML;
+      t.tagName = "div";
+      t.classList.add("table-wrapper");
+      t.innerHTML = `<table>${inner}</table>`;
+    }
+    return str && parsed.innerHTML;
+  });
+
   eleventyConfig.addTransform("htmlMinifier", (content, outputPath) => {
     if (
       process.env.NODE_ENV === "production" &&
@@ -322,12 +336,12 @@ module.exports = function (eleventyConfig) {
   eleventyConfig.addPlugin(pluginRss, {
     posthtmlRenderOptions: {
       closingSingleTag: "slash",
-      singleTags: ["link"]
-    }  
+      singleTags: ["link"],
+    },
   });
 
-  eleventyConfig.addFilter("dateToZulu", function(date){
-    if(!date) return "";
+  eleventyConfig.addFilter("dateToZulu", function (date) {
+    if (!date) return "";
     return new Date(date).toISOString("dd-MM-yyyyTHH:mm:ssZ");
   });
   eleventyConfig.addFilter("jsonify", function (variable) {
@@ -341,6 +355,17 @@ module.exports = function (eleventyConfig) {
       return variable.replaceAll("\\", "\\\\");
     }
     return variable;
+  });
+
+  eleventyConfig.addTransform("table", function (str) {
+    const parsed = parse(str);
+    for (const t of parsed.querySelectorAll(".cm-s-obsidian > table")) {
+      let inner = t.innerHTML;
+      t.tagName = "div";
+      t.classList.add("table-wrapper");
+      t.innerHTML = `<table>${inner}</table>`;
+    }
+    return str && parsed.innerHTML;
   });
 
   userEleventySetup(eleventyConfig);

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -187,10 +187,7 @@ module.exports = function (eleventyConfig) {
           if (frontMatter.data.permalink) {
             permalink = frontMatter.data.permalink;
           }
-          if (
-            frontMatter.data.tags &&
-            frontMatter.data.tags.indexOf("gardenEntry") != -1
-          ) {
+          if (frontMatter.data.tags && frontMatter.data.tags.indexOf("gardenEntry") != -1) {
             permalink = "/";
           }
           if (frontMatter.data.noteIcon) {

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -357,17 +357,6 @@ module.exports = function (eleventyConfig) {
     return variable;
   });
 
-  eleventyConfig.addTransform("table", function (str) {
-    const parsed = parse(str);
-    for (const t of parsed.querySelectorAll(".cm-s-obsidian > table")) {
-      let inner = t.innerHTML;
-      t.tagName = "div";
-      t.classList.add("table-wrapper");
-      t.innerHTML = `<table>${inner}</table>`;
-    }
-    return str && parsed.innerHTML;
-  });
-
   userEleventySetup(eleventyConfig);
 
   return {

--- a/src/site/styles/digital-garden-base.scss
+++ b/src/site/styles/digital-garden-base.scss
@@ -748,6 +748,6 @@ body.backlinks-note-icon .backlink[data-note-icon="3"]::before {
 
 .cm-s-obsidian {
     .table-wrapper {
-        overflow-x: scroll;
+        overflow-x: auto;
     }
 }

--- a/src/site/styles/digital-garden-base.scss
+++ b/src/site/styles/digital-garden-base.scss
@@ -517,7 +517,7 @@ ul.task-list {
     display: flex;
     align-items: center;
     min-width: 150px;
-    margin: 10px 40px; 
+    margin: 10px 40px;
     border: 1px solid var(--text-normal);
     cursor: pointer;
 
@@ -740,9 +740,14 @@ body.backlinks-note-icon .backlink[data-note-icon="3"]::before {
     }
 }
 
-
 .align-icon {
     display: inline-flex;
     align-items: center;
     justify-content: space-evenly;
+}
+
+.cm-s-obsidian {
+    .table-wrapper {
+        overflow-x: scroll;
+    }
 }


### PR DESCRIPTION
In some themes (at least in the Minimal theme and/or in all themes), markdown tables are not scrollable horizontally in mobiles.

That can be fixed by an `overflow-y: auto` on the `cm-s-obsidian` class but that breaks the styling. I've googled it a bit and found that in such situations tables should be wrapped in another container, and that container should have `overflow-y: auto`.

It is true that our current setup allows us to implement this without touching the core template, but I thought it was a problem most will face now or then and we can ship the solution with the template.