### PR TITLE
Move vercel.json to filesToAdd

### DIFF
--- a/plugin-info.json
+++ b/plugin-info.json
@@ -14,7 +14,8 @@
         "src/site/img/tree-2.svg",
         "src/site/img/tree-3.svg",
         "src/helpers/userUtils.js",
-        "src/helpers/userSetup.js"
+        "src/helpers/userSetup.js",
+        "vercel.json"
     ],
     "filesToModify": [
         ".eleventy.js",
@@ -63,7 +64,6 @@
         "netlify/functions/search/search.js",
         "src/site/get-theme.js",
         "api/search.js",
-        "vercel.json",
         "src/site/_data/eleventyComputed.js",
         "src/site/graph.njk"
     ]

--- a/plugin-info.json
+++ b/plugin-info.json
@@ -15,13 +15,13 @@
         "src/site/img/tree-3.svg",
         "src/helpers/userUtils.js",
         "src/helpers/userSetup.js",
-        "vercel.json"
+        "vercel.json",
+        "netlify.toml"
     ],
     "filesToModify": [
         ".eleventy.js",
         ".eleventyignore",
         "README.md",
-        "netlify.toml",
         "package-lock.json",
         "package.json",
         "src/site/404.njk",


### PR DESCRIPTION
**Merge this if it makes sense to you.**

Currently, `vercel.json` is in the `filesToModify` in the `plugin-info.json`. Any settings the users can put will be overridden in every update.

On the other hand, this file doesn't get modified often from the template's perspective. But users can add additional things. Like I make the GitHub silent.

Adding this to `filesToAdd` may allow users to have smoother updating experience.