### PR TITLE
fix: breakage in transform blockquotes function removes some html tags

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
         "@octokit/core": "^4.1.0",
         "@sindresorhus/slugify": "^1.1.0",
         "axios": "^1.2.2",
+        "cheerio": "^1.0.0-rc.12",
         "dotenv": "^16.0.3",
         "eleventy-favicon": "^1.1.2",
         "eleventy-plugin-nesting-toc": "^1.3.0",


### PR DESCRIPTION
Initially when rendering some pages I noticed there was no styling applied, or only partially applied.

By examining the html I noticed some tags from the nunjuck template file were missing.
For example : the main tag had been stripped off but not the content of my note, and since come of the css classes are applied on the main element the page had only partial styling.

The pages looked like the capture on this issue : https://github.com/oleeskild/obsidian-digital-garden/issues/294

Actually after doing some research, I found that the node html parser was silently failing to parse some content and that the resulting html was missing some tags.

To fix the function I needed to replace the parser, so I took the first one from npm that didn't fail on the generated html from my markdown note.
I took cheerio, I don't know if that is suitable for you.

The fix has been pushed on my dev garden : https://github.com/bayang/garden-dev

