### PR TITLE
Add null checks for empty dataview queries

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -375,12 +375,12 @@ module.exports = function (eleventyConfig) {
     )) {
       t.classList.add("dataview");
       t.classList.add("table-view-table");
-      t.querySelector("thead").classList.add("table-view-thead");
-      t.querySelector("tbody").classList.add("table-view-tbody");
-      t.querySelectorAll("thead > tr").forEach((tr) => {
+      t.querySelector("thead")?.classList.add("table-view-thead");
+      t.querySelector("tbody")?.classList.add("table-view-tbody");
+      t.querySelectorAll("thead > tr")?.forEach((tr) => {
         tr.classList.add("table-view-tr-header");
       });
-      t.querySelectorAll("thead > tr > th").forEach((th) => {
+      t.querySelectorAll("thead > tr > th")?.forEach((th) => {
         th.classList.add("table-view-th");
       });
     }


### PR DESCRIPTION
If you have a dataview query in a note that does not return any results, the current dataview styling throws an error as it tries to access `.classList` of null