### PR TITLE
removing vulnerable favicon generator and replacing it with alternative

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -2,7 +2,7 @@ const slugify = require("@sindresorhus/slugify");
 const markdownIt = require("markdown-it");
 const fs = require("fs");
 const matter = require("gray-matter");
-const faviconPlugin = require("eleventy-favicon");
+const faviconsPlugin = require("eleventy-plugin-gen-favicons");
 const tocPlugin = require("eleventy-plugin-nesting-toc");
 const { parse } = require("node-html-parser");
 const htmlMinifier = require("html-minifier");
@@ -408,7 +408,7 @@ module.exports = function (eleventyConfig) {
   eleventyConfig.addPassthroughCopy("src/site/img");
   eleventyConfig.addPassthroughCopy("src/site/scripts");
   eleventyConfig.addPassthroughCopy("src/site/styles/_theme.*.css");
-  eleventyConfig.addPlugin(faviconPlugin, { destination: "dist" });
+  eleventyConfig.addPlugin(faviconsPlugin, { destination: "dist" });
   eleventyConfig.addPlugin(tocPlugin, {
     ul: true,
     tags: ["h1", "h2", "h3", "h4", "h5", "h6"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
                 "@sindresorhus/slugify": "^1.1.0",
                 "axios": "^1.2.2",
                 "dotenv": "^16.0.3",
-                "eleventy-favicon": "^1.1.2",
+                "eleventy-plugin-gen-favicons": "^1.1.2",
                 "eleventy-plugin-nesting-toc": "^1.3.0",
                 "fs-file-tree": "^1.1.1",
                 "glob": "^10.2.1",
@@ -31,7 +31,7 @@
                 "markdown-it-task-checkbox": "^1.0.6"
             },
             "devDependencies": {
-                "@11ty/eleventy": "^2.0.0",
+                "@11ty/eleventy": "^2.0.1",
                 "@11ty/eleventy-plugin-rss": "^1.2.0",
                 "cross-env": "^7.0.3",
                 "html-minifier": "^4.0.0",
@@ -206,28 +206,6 @@
                 "node": ">=14.0.0"
             }
         },
-        "node_modules/@11ty/eleventy-img/node_modules/sharp": {
-            "version": "0.31.3",
-            "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.31.3.tgz",
-            "integrity": "sha512-XcR4+FCLBFKw1bdB+GEhnUNXNXvnt0tDo4WsBsraKymuo/IAuPuCBVAL2wIkUw2r/dwFW5Q5+g66Kwl2dgDFVg==",
-            "hasInstallScript": true,
-            "dependencies": {
-                "color": "^4.2.3",
-                "detect-libc": "^2.0.1",
-                "node-addon-api": "^5.0.0",
-                "prebuild-install": "^7.1.1",
-                "semver": "^7.3.8",
-                "simple-get": "^4.0.1",
-                "tar-fs": "^2.1.1",
-                "tunnel-agent": "^0.6.0"
-            },
-            "engines": {
-                "node": ">=14.15.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/libvips"
-            }
-        },
         "node_modules/@11ty/eleventy-plugin-rss": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/@11ty/eleventy-plugin-rss/-/eleventy-plugin-rss-1.2.0.tgz",
@@ -304,9 +282,9 @@
             }
         },
         "node_modules/@azure/core-http": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@azure/core-http/-/core-http-3.0.0.tgz",
-            "integrity": "sha512-BxI2SlGFPPz6J1XyZNIVUf0QZLBKFX+ViFjKOkzqD18J1zOINIQ8JSBKKr+i+v8+MB6LacL6Nn/sP/TE13+s2Q==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/@azure/core-http/-/core-http-3.0.1.tgz",
+            "integrity": "sha512-A3x+um3cAPgQe42Lu7Iv/x8/fNjhL/nIoEfqFxfn30EyxK6zC13n+OUxzZBRC0IzQqssqIbt4INf5YG7lYYFtw==",
             "dependencies": {
                 "@azure/abort-controller": "^1.0.0",
                 "@azure/core-auth": "^1.3.0",
@@ -321,7 +299,7 @@
                 "tslib": "^2.2.0",
                 "tunnel": "^0.0.6",
                 "uuid": "^8.3.0",
-                "xml2js": "^0.4.19"
+                "xml2js": "^0.5.0"
             },
             "engines": {
                 "node": ">=14.0.0"
@@ -736,21 +714,6 @@
                 "node": ">=0.4.0"
             }
         },
-        "node_modules/ajv": {
-            "version": "6.12.6",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-            "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-            "dependencies": {
-                "fast-deep-equal": "^3.1.1",
-                "fast-json-stable-stringify": "^2.0.0",
-                "json-schema-traverse": "^0.4.1",
-                "uri-js": "^4.2.2"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/epoberezkin"
-            }
-        },
         "node_modules/ansi-colors": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
@@ -837,6 +800,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
             "integrity": "sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==",
+            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -847,27 +811,11 @@
             "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
             "dev": true
         },
-        "node_modules/asn1": {
-            "version": "0.2.6",
-            "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
-            "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
-            "dependencies": {
-                "safer-buffer": "~2.1.0"
-            }
-        },
         "node_modules/assert-never": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/assert-never/-/assert-never-1.2.1.tgz",
             "integrity": "sha512-TaTivMB6pYI1kXwrFlEhLeGfOqoDNdTxjCdwRfFFkEA30Eu+k48W34nlok2EYWJfFFzqaEmichdNM7th6M5HNw==",
             "dev": true
-        },
-        "node_modules/assert-plus": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-            "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-            "engines": {
-                "node": ">=0.8"
-            }
         },
         "node_modules/assured": {
             "version": "1.0.15",
@@ -888,19 +836,6 @@
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
             "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
-        },
-        "node_modules/aws-sign2": {
-            "version": "0.7.0",
-            "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-            "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
-            "engines": {
-                "node": "*"
-            }
-        },
-        "node_modules/aws4": {
-            "version": "1.11.0",
-            "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
-            "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
         },
         "node_modules/axios": {
             "version": "1.3.5",
@@ -987,26 +922,10 @@
                 "url": "https://github.com/sponsors/wooorm"
             }
         },
-        "node_modules/bcrypt-pbkdf": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-            "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
-            "dependencies": {
-                "tweetnacl": "^0.14.3"
-            }
-        },
         "node_modules/before-after-hook": {
             "version": "2.2.2",
             "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.2.tgz",
             "integrity": "sha512-3pZEU3NT5BFUo/AD5ERPWOgQOCZITni6iavr5AUw5AUwQjMlI0kzu5btnyD39AF0gUEsDPwJT+oY1ORBJijPjQ=="
-        },
-        "node_modules/bignumber.js": {
-            "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-2.4.0.tgz",
-            "integrity": "sha1-g4qZLan51zfg9LLbC+YrsJ3Qxeg=",
-            "engines": {
-                "node": "*"
-            }
         },
         "node_modules/binary-extensions": {
             "version": "2.2.0",
@@ -1035,11 +954,6 @@
                 "inherits": "^2.0.4",
                 "readable-stream": "^3.4.0"
             }
-        },
-        "node_modules/bmp-js": {
-            "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/bmp-js/-/bmp-js-0.0.1.tgz",
-            "integrity": "sha1-WtAUcJnROp84qnuZrx1ueGZu038="
         },
         "node_modules/boolbase": {
             "version": "1.0.0",
@@ -1090,33 +1004,6 @@
                 "ieee754": "^1.1.13"
             }
         },
-        "node_modules/buffer-alloc": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
-            "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
-            "dependencies": {
-                "buffer-alloc-unsafe": "^1.1.0",
-                "buffer-fill": "^1.0.0"
-            }
-        },
-        "node_modules/buffer-alloc-unsafe": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
-            "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg=="
-        },
-        "node_modules/buffer-equal": {
-            "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-0.0.1.tgz",
-            "integrity": "sha1-kbx0sR6kBbyRa8aqkI+q+ltKrEs=",
-            "engines": {
-                "node": ">=0.4.0"
-            }
-        },
-        "node_modules/buffer-fill": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
-            "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw="
-        },
         "node_modules/call-bind": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
@@ -1148,11 +1035,6 @@
                 "regex-escape": "^3.4.10",
                 "uc-first-array": "^1.1.10"
             }
-        },
-        "node_modules/caseless": {
-            "version": "0.12.0",
-            "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-            "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
         },
         "node_modules/chalk": {
             "version": "2.4.2",
@@ -1418,17 +1300,6 @@
                 "url": "https://github.com/sponsors/fb55"
             }
         },
-        "node_modules/dashdash": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-            "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-            "dependencies": {
-                "assert-plus": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=0.10"
-            }
-        },
         "node_modules/debug": {
             "version": "4.3.4",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -1548,11 +1419,6 @@
                 "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
             }
         },
-        "node_modules/dom-walk": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
-            "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w=="
-        },
         "node_modules/domelementtype": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
@@ -1599,15 +1465,6 @@
                 "node": ">=12"
             }
         },
-        "node_modules/ecc-jsbn": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-            "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
-            "dependencies": {
-                "jsbn": "~0.1.0",
-                "safer-buffer": "^2.1.0"
-            }
-        },
         "node_modules/ee-first": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -1629,13 +1486,14 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/eleventy-favicon": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/eleventy-favicon/-/eleventy-favicon-1.1.3.tgz",
-            "integrity": "sha512-eA051s+frbtjlT/MMSoqo4ObAd8FLo//DxH2LdjHQFPqL1JJRz/tuQqJy+0x2qgvB18w2Hwtrcg6PI3NGRsv9w==",
+        "node_modules/eleventy-plugin-gen-favicons": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/eleventy-plugin-gen-favicons/-/eleventy-plugin-gen-favicons-1.1.2.tgz",
+            "integrity": "sha512-DtxS3J+ujDVZ9oP5RTOTxwET2K7S7WEvQ7XE/S3TwM7uQR/NOqHibuZXyftutK22EU1UInQc2yP1JZ7mtnWJUQ==",
             "dependencies": {
-                "sharp": "^0.30.4",
-                "to-ico": "^1.1.5"
+                "fast-deep-equal": "^3.1.3",
+                "png-to-ico": "^2.1.8",
+                "sharp": "^0.31.3"
             }
         },
         "node_modules/eleventy-plugin-nesting-toc": {
@@ -1748,11 +1606,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/es6-promise": {
-            "version": "3.3.1",
-            "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz",
-            "integrity": "sha1-oIzd6EzNvzTQJ6FFG8kdS80ophM="
-        },
         "node_modules/escape-goat": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/escape-goat/-/escape-goat-3.0.0.tgz",
@@ -1814,11 +1667,6 @@
                 "node": ">=0.8.x"
             }
         },
-        "node_modules/exif-parser": {
-            "version": "0.1.12",
-            "resolved": "https://registry.npmjs.org/exif-parser/-/exif-parser-0.1.12.tgz",
-            "integrity": "sha1-WKnS1ywCwfbwKg70qRZicrd2CSI="
-        },
         "node_modules/expand-template": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
@@ -1826,11 +1674,6 @@
             "engines": {
                 "node": ">=6"
             }
-        },
-        "node_modules/extend": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-            "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
         },
         "node_modules/extend-shallow": {
             "version": "2.0.1",
@@ -1842,14 +1685,6 @@
             "engines": {
                 "node": ">=0.10.0"
             }
-        },
-        "node_modules/extsprintf": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-            "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-            "engines": [
-                "node >=0.6.0"
-            ]
         },
         "node_modules/fast-deep-equal": {
             "version": "3.1.3",
@@ -1872,11 +1707,6 @@
                 "node": ">=8.6.0"
             }
         },
-        "node_modules/fast-json-stable-stringify": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-            "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
-        },
         "node_modules/fastq": {
             "version": "1.14.0",
             "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.14.0.tgz",
@@ -1884,14 +1714,6 @@
             "dev": true,
             "dependencies": {
                 "reusify": "^1.0.4"
-            }
-        },
-        "node_modules/file-type": {
-            "version": "3.9.0",
-            "resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
-            "integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek=",
-            "engines": {
-                "node": ">=0.10.0"
             }
         },
         "node_modules/filelist": {
@@ -2053,14 +1875,6 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
-        "node_modules/forever-agent": {
-            "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-            "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-            "engines": {
-                "node": "*"
-            }
-        },
         "node_modules/form-data": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
@@ -2138,18 +1952,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/get-stream": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
-            "integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=",
-            "dependencies": {
-                "object-assign": "^4.0.1",
-                "pinkie-promise": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/get-symbol-description": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
@@ -2164,14 +1966,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/getpass": {
-            "version": "0.1.7",
-            "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-            "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-            "dependencies": {
-                "assert-plus": "^1.0.0"
             }
         },
         "node_modules/github-from-package": {
@@ -2243,15 +2037,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/global": {
-            "version": "4.4.0",
-            "resolved": "https://registry.npmjs.org/global/-/global-4.4.0.tgz",
-            "integrity": "sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==",
-            "dependencies": {
-                "min-document": "^2.19.0",
-                "process": "^0.11.10"
-            }
-        },
         "node_modules/graceful-fs": {
             "version": "4.2.11",
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -2297,27 +2082,6 @@
             },
             "optionalDependencies": {
                 "uglify-js": "^3.1.4"
-            }
-        },
-        "node_modules/har-schema": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-            "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/har-validator": {
-            "version": "5.1.5",
-            "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
-            "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
-            "deprecated": "this library is no longer supported",
-            "dependencies": {
-                "ajv": "^6.12.3",
-                "har-schema": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=6"
             }
         },
         "node_modules/has": {
@@ -2446,20 +2210,6 @@
                 "node": ">= 0.10"
             }
         },
-        "node_modules/http-signature": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-            "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-            "dependencies": {
-                "assert-plus": "^1.0.0",
-                "jsprim": "^1.2.2",
-                "sshpk": "^1.7.0"
-            },
-            "engines": {
-                "node": ">=0.8",
-                "npm": ">=1.3.7"
-            }
-        },
         "node_modules/ieee754": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -2478,17 +2228,6 @@
                     "url": "https://feross.org/support"
                 }
             ]
-        },
-        "node_modules/image-size": {
-            "version": "0.5.5",
-            "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.5.5.tgz",
-            "integrity": "sha1-Cd/Uq50g4p6xw+gLiZA3jfnjy5w=",
-            "bin": {
-                "image-size": "bin/image-size.js"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
         },
         "node_modules/inflight": {
             "version": "1.0.6",
@@ -2521,14 +2260,6 @@
             },
             "engines": {
                 "node": ">= 0.4"
-            }
-        },
-        "node_modules/ip-regex": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-1.0.3.tgz",
-            "integrity": "sha1-3FiQdvZZ9BnCIgOaMzFvHHOH7/0=",
-            "engines": {
-                "node": ">=0.10.0"
             }
         },
         "node_modules/is-alphabetical": {
@@ -2685,11 +2416,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/is-function": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.2.tgz",
-            "integrity": "sha512-lw7DUp0aWXYg+CBCN+JKkcE0Q2RayZnSvnZBlwgxHBQhqt5pZNVy4Ri7H9GmmXkdu7LUthszM+Tor1u/2iBcpQ=="
-        },
         "node_modules/is-glob": {
             "version": "4.0.3",
             "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -2813,11 +2539,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/is-typedarray": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-            "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
-        },
         "node_modules/is-weakref": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
@@ -2843,11 +2564,6 @@
             "engines": {
                 "node": ">=6.0"
             }
-        },
-        "node_modules/isstream": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-            "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
         },
         "node_modules/jackspeak": {
             "version": "2.0.3",
@@ -2954,44 +2670,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/jimp": {
-            "version": "0.2.28",
-            "resolved": "https://registry.npmjs.org/jimp/-/jimp-0.2.28.tgz",
-            "integrity": "sha512-9HT7DA279xkTlry2oG30s6AtOUglNiY2UdyYpj0yNI4/NBv8PmdNC0gcldgMU4HqvbUlrM3+v+6GaHnTkH23JQ==",
-            "dependencies": {
-                "bignumber.js": "^2.1.0",
-                "bmp-js": "0.0.3",
-                "es6-promise": "^3.0.2",
-                "exif-parser": "^0.1.9",
-                "file-type": "^3.1.0",
-                "jpeg-js": "^0.2.0",
-                "load-bmfont": "^1.2.3",
-                "mime": "^1.3.4",
-                "mkdirp": "0.5.1",
-                "pixelmatch": "^4.0.0",
-                "pngjs": "^3.0.0",
-                "read-chunk": "^1.0.1",
-                "request": "^2.65.0",
-                "stream-to-buffer": "^0.1.0",
-                "tinycolor2": "^1.1.2",
-                "url-regex": "^3.0.0"
-            }
-        },
-        "node_modules/jimp/node_modules/bmp-js": {
-            "version": "0.0.3",
-            "resolved": "https://registry.npmjs.org/bmp-js/-/bmp-js-0.0.3.tgz",
-            "integrity": "sha1-ZBE+nHzxICs3btYHvzBibr5XsYo="
-        },
-        "node_modules/jimp/node_modules/jpeg-js": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.2.0.tgz",
-            "integrity": "sha512-Ni9PffhJtYtdD7VwxH6V2MnievekGfUefosGCHadog0/jAevRu6HPjYeMHbUemn0IPE8d4wGa8UsOGsX+iKy2g=="
-        },
-        "node_modules/jpeg-js": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.1.2.tgz",
-            "integrity": "sha512-CiRVjMKBUp6VYtGwzRjrdnro41yMwKGOWdP9ATXqmixdz2n7KHNwdqthTYSSbOKj/Ha79Gct1sA8ZQpse55TYA=="
-        },
         "node_modules/js-stringify": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/js-stringify/-/js-stringify-1.0.2.tgz",
@@ -3010,45 +2688,11 @@
                 "js-yaml": "bin/js-yaml.js"
             }
         },
-        "node_modules/jsbn": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-            "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
-        },
         "node_modules/json-parse-better-errors": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
             "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
             "dev": true
-        },
-        "node_modules/json-schema": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
-            "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
-        },
-        "node_modules/json-schema-traverse": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
-        },
-        "node_modules/json-stringify-safe": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-            "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
-        },
-        "node_modules/jsprim": {
-            "version": "1.4.2",
-            "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
-            "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
-            "dependencies": {
-                "assert-plus": "1.0.0",
-                "extsprintf": "1.3.0",
-                "json-schema": "0.4.0",
-                "verror": "1.10.0"
-            },
-            "engines": {
-                "node": ">=0.6.0"
-            }
         },
         "node_modules/jstransformer": {
             "version": "1.0.0",
@@ -3154,21 +2798,6 @@
             "resolved": "https://registry.npmjs.org/list-to-array/-/list-to-array-1.1.0.tgz",
             "integrity": "sha512-+dAZZ2mM+/m+vY9ezfoueVvrgnHIGi5FvgSymbIgJOFwiznWyA59mav95L+Mc6xPtL3s9gm5eNTlNtxJLbNM1g==",
             "dev": true
-        },
-        "node_modules/load-bmfont": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/load-bmfont/-/load-bmfont-1.4.1.tgz",
-            "integrity": "sha512-8UyQoYmdRDy81Brz6aLAUhfZLwr5zV0L3taTQ4hju7m6biuwiWiJXjPhBJxbUQJA8PrkvJ/7Enqmwk2sM14soA==",
-            "dependencies": {
-                "buffer-equal": "0.0.1",
-                "mime": "^1.3.4",
-                "parse-bmfont-ascii": "^1.0.3",
-                "parse-bmfont-binary": "^1.0.5",
-                "parse-bmfont-xml": "^1.1.4",
-                "phin": "^2.9.1",
-                "xhr": "^2.0.1",
-                "xtend": "^4.0.0"
-            }
         },
         "node_modules/load-json-file": {
             "version": "4.0.0",
@@ -3391,14 +3020,6 @@
                 "node": ">=8.6"
             }
         },
-        "node_modules/mime": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
-            "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
-            "bin": {
-                "mime": "cli.js"
-            }
-        },
         "node_modules/mime-db": {
             "version": "1.51.0",
             "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.51.0.tgz",
@@ -3427,14 +3048,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/min-document": {
-            "version": "2.19.0",
-            "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
-            "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
-            "dependencies": {
-                "dom-walk": "^0.1.0"
             }
         },
         "node_modules/minimatch": {
@@ -3474,12 +3087,12 @@
             "integrity": "sha512-7NO5s6n10TIV96d4g2uDpG7ZDpIhMh0QNfGdJw/W47JswFcosz457wqz/b5sAKvl12sxINGFCn80NZHKwxQEXA=="
         },
         "node_modules/mkdirp": {
-            "version": "0.5.1",
-            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-            "integrity": "sha512-SknJC52obPfGQPnjIkXbmA6+5H15E+fR+E4iR2oQ3zzCLbd7/ONua69R/Gw7AgkTLsRG+r5fzksYwWe1AgTyWA==",
-            "deprecated": "Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)",
+            "version": "0.5.6",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+            "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+            "dev": true,
             "dependencies": {
-                "minimist": "0.0.8"
+                "minimist": "^1.2.6"
             },
             "bin": {
                 "mkdirp": "bin/cmd.js"
@@ -3489,11 +3102,6 @@
             "version": "0.5.3",
             "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
             "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
-        },
-        "node_modules/mkdirp/node_modules/minimist": {
-            "version": "0.0.8",
-            "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-            "integrity": "sha512-miQKw5Hv4NS1Psg2517mV4e4dYNaO3++hjAvLOAzKqZ61rH8NS1SK+vbfBWZ5PY/Me/bEWhUwqMghEW5Fb9T7Q=="
         },
         "node_modules/moo": {
             "version": "0.5.2",
@@ -3842,9 +3450,9 @@
             }
         },
         "node_modules/nunjucks": {
-            "version": "3.2.3",
-            "resolved": "https://registry.npmjs.org/nunjucks/-/nunjucks-3.2.3.tgz",
-            "integrity": "sha512-psb6xjLj47+fE76JdZwskvwG4MYsQKXUtMsPh6U0YMvmyjRtKRFcxnlXGWglNybtNTNVmGdp94K62/+NjF5FDQ==",
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/nunjucks/-/nunjucks-3.2.4.tgz",
+            "integrity": "sha512-26XRV6BhkgK0VOxfbU5cQI+ICFUtMLixv1noZn1tGU38kQH5A5nmmbk/O45xdyBhD1esk47nKrY0mvQpZIhRjQ==",
             "dev": true,
             "dependencies": {
                 "a-sync-waterfall": "^1.0.0",
@@ -3866,18 +3474,11 @@
                 }
             }
         },
-        "node_modules/oauth-sign": {
-            "version": "0.9.0",
-            "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-            "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
-            "engines": {
-                "node": "*"
-            }
-        },
         "node_modules/object-assign": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
             "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -3981,30 +3582,6 @@
                 "no-case": "^2.2.0"
             }
         },
-        "node_modules/parse-bmfont-ascii": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/parse-bmfont-ascii/-/parse-bmfont-ascii-1.0.6.tgz",
-            "integrity": "sha1-Eaw8P/WPfCAgqyJ2kHkQjU36AoU="
-        },
-        "node_modules/parse-bmfont-binary": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/parse-bmfont-binary/-/parse-bmfont-binary-1.0.6.tgz",
-            "integrity": "sha1-0Di0dtPp3Z2x4RoLDlOiJ5K2kAY="
-        },
-        "node_modules/parse-bmfont-xml": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/parse-bmfont-xml/-/parse-bmfont-xml-1.1.4.tgz",
-            "integrity": "sha512-bjnliEOmGv3y1aMEfREMBJ9tfL3WR0i0CKPj61DnSLaoxWR3nLrsQrEbCId/8rF4NyRF0cCqisSVXyQYWM+mCQ==",
-            "dependencies": {
-                "xml-parse-from-string": "^1.0.0",
-                "xml2js": "^0.4.5"
-            }
-        },
-        "node_modules/parse-headers": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.5.tgz",
-            "integrity": "sha512-ft3iAoLOB/MlwbNXgzy43SWGP6sQki2jQvAyBg/zDFAgr9bfNWZIUj42Kw2eJIl8kEi4PbgE6U1Zau/HwI75HA=="
-        },
         "node_modules/parse-json": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
@@ -4013,17 +3590,6 @@
             "dependencies": {
                 "error-ex": "^1.3.1",
                 "json-parse-better-errors": "^1.0.1"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/parse-png": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/parse-png/-/parse-png-1.1.2.tgz",
-            "integrity": "sha1-9cKtfHmTSQmGAgooTBmu5FlxH/I=",
-            "dependencies": {
-                "pngjs": "^3.2.0"
             },
             "engines": {
                 "node": ">=4"
@@ -4120,16 +3686,6 @@
                 "node": ">=4"
             }
         },
-        "node_modules/performance-now": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-            "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
-        },
-        "node_modules/phin": {
-            "version": "2.9.3",
-            "resolved": "https://registry.npmjs.org/phin/-/phin-2.9.3.tgz",
-            "integrity": "sha512-CzFr90qM24ju5f88quFC/6qohjC144rehe5n6DH900lgXmUe86+xCKc10ev56gRKC4/BkHUoG4uSiQgBiIXwDA=="
-        },
         "node_modules/picomatch": {
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
@@ -4163,36 +3719,6 @@
                 "node": ">=4"
             }
         },
-        "node_modules/pinkie": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-            "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/pinkie-promise": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-            "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-            "dependencies": {
-                "pinkie": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/pixelmatch": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/pixelmatch/-/pixelmatch-4.0.2.tgz",
-            "integrity": "sha1-j0fc7FARtHe2fbA8JDvB8wheiFQ=",
-            "dependencies": {
-                "pngjs": "^3.0.0"
-            },
-            "bin": {
-                "pixelmatch": "bin/pixelmatch"
-            }
-        },
         "node_modules/please-upgrade-node": {
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz",
@@ -4202,12 +3728,33 @@
                 "semver-compare": "^1.0.0"
             }
         },
-        "node_modules/pngjs": {
-            "version": "3.4.0",
-            "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-3.4.0.tgz",
-            "integrity": "sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w==",
+        "node_modules/png-to-ico": {
+            "version": "2.1.8",
+            "resolved": "https://registry.npmjs.org/png-to-ico/-/png-to-ico-2.1.8.tgz",
+            "integrity": "sha512-Nf+IIn/cZ/DIZVdGveJp86NG5uNib1ZXMiDd/8x32HCTeKSvgpyg6D/6tUBn1QO/zybzoMK0/mc3QRgAyXdv9w==",
+            "dependencies": {
+                "@types/node": "^17.0.36",
+                "minimist": "^1.2.6",
+                "pngjs": "^6.0.0"
+            },
+            "bin": {
+                "png-to-ico": "bin/cli.js"
+            },
             "engines": {
-                "node": ">=4.0.0"
+                "node": ">=8"
+            }
+        },
+        "node_modules/png-to-ico/node_modules/@types/node": {
+            "version": "17.0.45",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
+            "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw=="
+        },
+        "node_modules/pngjs": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-6.0.0.tgz",
+            "integrity": "sha512-TRzzuFRRmEoSW/p1KVAmiOgPco2Irlah+bGFCeNfJXxxYGwSw7YwAOAcd7X28K/m5bjBWKsC29KyoMfHbypayg==",
+            "engines": {
+                "node": ">=12.13.0"
             }
         },
         "node_modules/posthtml": {
@@ -4355,11 +3902,6 @@
             "integrity": "sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw==",
             "dev": true
         },
-        "node_modules/psl": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
-            "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
-        },
         "node_modules/pug": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/pug/-/pug-3.0.2.tgz",
@@ -4493,14 +4035,6 @@
                 "once": "^1.3.1"
             }
         },
-        "node_modules/punycode": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-            "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-            "engines": {
-                "node": ">=6"
-            }
-        },
         "node_modules/queue": {
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/queue/-/queue-6.0.2.tgz",
@@ -4541,14 +4075,6 @@
             },
             "bin": {
                 "rc": "cli.js"
-            }
-        },
-        "node_modules/read-chunk": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/read-chunk/-/read-chunk-1.0.1.tgz",
-            "integrity": "sha1-X2jKswfmY/GZk1J9m1icrORmEZQ=",
-            "engines": {
-                "node": ">=0.10.0"
             }
         },
         "node_modules/read-dir-and-stat": {
@@ -4637,95 +4163,6 @@
             "dev": true,
             "engines": {
                 "node": ">= 0.10"
-            }
-        },
-        "node_modules/request": {
-            "version": "2.88.2",
-            "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
-            "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
-            "deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
-            "dependencies": {
-                "aws-sign2": "~0.7.0",
-                "aws4": "^1.8.0",
-                "caseless": "~0.12.0",
-                "combined-stream": "~1.0.6",
-                "extend": "~3.0.2",
-                "forever-agent": "~0.6.1",
-                "form-data": "~2.3.2",
-                "har-validator": "~5.1.3",
-                "http-signature": "~1.2.0",
-                "is-typedarray": "~1.0.0",
-                "isstream": "~0.1.2",
-                "json-stringify-safe": "~5.0.1",
-                "mime-types": "~2.1.19",
-                "oauth-sign": "~0.9.0",
-                "performance-now": "^2.1.0",
-                "qs": "~6.5.2",
-                "safe-buffer": "^5.1.2",
-                "tough-cookie": "~2.5.0",
-                "tunnel-agent": "^0.6.0",
-                "uuid": "^3.3.2"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
-        },
-        "node_modules/request/node_modules/form-data": {
-            "version": "2.3.3",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-            "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-            "dependencies": {
-                "asynckit": "^0.4.0",
-                "combined-stream": "^1.0.6",
-                "mime-types": "^2.1.12"
-            },
-            "engines": {
-                "node": ">= 0.12"
-            }
-        },
-        "node_modules/request/node_modules/qs": {
-            "version": "6.5.3",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
-            "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==",
-            "engines": {
-                "node": ">=0.6"
-            }
-        },
-        "node_modules/request/node_modules/tough-cookie": {
-            "version": "2.5.0",
-            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
-            "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
-            "dependencies": {
-                "psl": "^1.1.28",
-                "punycode": "^2.1.1"
-            },
-            "engines": {
-                "node": ">=0.8"
-            }
-        },
-        "node_modules/request/node_modules/uuid": {
-            "version": "3.4.0",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-            "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-            "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
-            "bin": {
-                "uuid": "bin/uuid"
-            }
-        },
-        "node_modules/resize-img": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/resize-img/-/resize-img-1.1.2.tgz",
-            "integrity": "sha512-/4nKUmuNPuM6gYTWad136ica81baOVjpesgv8FGaIvP0KWcbCWahOWBKaM4tFoM+aVcSA+qQDg28pcnIzFRpJw==",
-            "dependencies": {
-                "bmp-js": "0.0.1",
-                "file-type": "^3.8.0",
-                "get-stream": "^2.0.0",
-                "jimp": "^0.2.21",
-                "jpeg-js": "^0.1.1",
-                "parse-png": "^1.1.1"
-            },
-            "engines": {
-                "node": ">=4"
             }
         },
         "node_modules/resolve": {
@@ -4829,11 +4266,6 @@
                 }
             ]
         },
-        "node_modules/safer-buffer": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
-        },
         "node_modules/same-time": {
             "version": "2.3.5",
             "resolved": "https://registry.npmjs.org/same-time/-/same-time-2.3.5.tgz",
@@ -4922,22 +4354,22 @@
             }
         },
         "node_modules/sharp": {
-            "version": "0.30.7",
-            "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.30.7.tgz",
-            "integrity": "sha512-G+MY2YW33jgflKPTXXptVO28HvNOo9G3j0MybYAHeEmby+QuD2U98dT6ueht9cv/XDqZspSpIhoSW+BAKJ7Hig==",
+            "version": "0.31.3",
+            "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.31.3.tgz",
+            "integrity": "sha512-XcR4+FCLBFKw1bdB+GEhnUNXNXvnt0tDo4WsBsraKymuo/IAuPuCBVAL2wIkUw2r/dwFW5Q5+g66Kwl2dgDFVg==",
             "hasInstallScript": true,
             "dependencies": {
                 "color": "^4.2.3",
                 "detect-libc": "^2.0.1",
                 "node-addon-api": "^5.0.0",
                 "prebuild-install": "^7.1.1",
-                "semver": "^7.3.7",
+                "semver": "^7.3.8",
                 "simple-get": "^4.0.1",
                 "tar-fs": "^2.1.1",
                 "tunnel-agent": "^0.6.0"
             },
             "engines": {
-                "node": ">=12.13.0"
+                "node": ">=14.15.0"
             },
             "funding": {
                 "url": "https://opencollective.com/libvips"
@@ -5156,30 +4588,6 @@
             "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
             "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
         },
-        "node_modules/sshpk": {
-            "version": "1.17.0",
-            "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.17.0.tgz",
-            "integrity": "sha512-/9HIEs1ZXGhSPE8X6Ccm7Nam1z8KcoCqPdI7ecm1N33EzAetWahvQWVqLZtaZQ+IDKX4IyA2o0gBzqIMkAagHQ==",
-            "dependencies": {
-                "asn1": "~0.2.3",
-                "assert-plus": "^1.0.0",
-                "bcrypt-pbkdf": "^1.0.0",
-                "dashdash": "^1.12.0",
-                "ecc-jsbn": "~0.1.1",
-                "getpass": "^0.1.1",
-                "jsbn": "~0.1.0",
-                "safer-buffer": "^2.0.2",
-                "tweetnacl": "~0.14.0"
-            },
-            "bin": {
-                "sshpk-conv": "bin/sshpk-conv",
-                "sshpk-sign": "bin/sshpk-sign",
-                "sshpk-verify": "bin/sshpk-verify"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/ssri": {
             "version": "8.0.1",
             "resolved": "https://registry.npmjs.org/ssri/-/ssri-8.0.1.tgz",
@@ -5197,25 +4605,6 @@
             "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
             "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
             "dev": true,
-            "engines": {
-                "node": ">= 0.8"
-            }
-        },
-        "node_modules/stream-to": {
-            "version": "0.2.2",
-            "resolved": "https://registry.npmjs.org/stream-to/-/stream-to-0.2.2.tgz",
-            "integrity": "sha1-hDBgmNhf25kLn6MAsbPM9V6O8B0=",
-            "engines": {
-                "node": ">= 0.10.0"
-            }
-        },
-        "node_modules/stream-to-buffer": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/stream-to-buffer/-/stream-to-buffer-0.1.0.tgz",
-            "integrity": "sha1-JnmdkDqyAlyb1VCsRxcbAPjdgKk=",
-            "dependencies": {
-                "stream-to": "~0.2.0"
-            },
             "engines": {
                 "node": ">= 0.8"
             }
@@ -5370,34 +4759,11 @@
                 "node": ">=6"
             }
         },
-        "node_modules/tinycolor2": {
-            "version": "1.4.2",
-            "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.4.2.tgz",
-            "integrity": "sha512-vJhccZPs965sV/L2sU4oRQVAos0pQXwsvTLkWYdqJ+a8Q5kPFzJTuOFwy7UniPli44NKQGAglksjvOcpo95aZA==",
-            "engines": {
-                "node": "*"
-            }
-        },
         "node_modules/to-fast-properties": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
             "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
             "dev": true,
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/to-ico": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/to-ico/-/to-ico-1.1.5.tgz",
-            "integrity": "sha512-5kIh7m7bkIlqIESEZkL8gAMMzucXKfPe3hX2FoDY5HEAfD9OJU+Qh9b6Enp74w0qRcxVT5ejss66PHKqc3AVkg==",
-            "dependencies": {
-                "arrify": "^1.0.1",
-                "buffer-alloc": "^1.1.0",
-                "image-size": "^0.5.0",
-                "parse-png": "^1.0.0",
-                "resize-img": "^1.1.0"
-            },
             "engines": {
                 "node": ">=4"
             }
@@ -5448,11 +4814,6 @@
             "engines": {
                 "node": "*"
             }
-        },
-        "node_modules/tweetnacl": {
-            "version": "0.14.5",
-            "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-            "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
         },
         "node_modules/typpy": {
             "version": "2.3.13",
@@ -5527,25 +4888,6 @@
             "integrity": "sha512-WRbjgmYzgXkCV7zNVpy5YgrHgbBv126rMALQQMrmzOVC4GM2waQ9x7xtm8VU+1yF2kWyPzI9zbZ48n4vSxwfSA==",
             "dev": true
         },
-        "node_modules/uri-js": {
-            "version": "4.4.1",
-            "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
-            "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-            "dependencies": {
-                "punycode": "^2.1.0"
-            }
-        },
-        "node_modules/url-regex": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/url-regex/-/url-regex-3.2.0.tgz",
-            "integrity": "sha512-dQ9cJzMou5OKr6ZzfvwJkCq3rC72PNXhqz0v3EIhF4a3Np+ujr100AhUx2cKx5ei3iymoJpJrPB3sVSEMdqAeg==",
-            "dependencies": {
-                "ip-regex": "^1.0.1"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/util-deprecate": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -5576,24 +4918,6 @@
                 "spdx-correct": "^3.0.0",
                 "spdx-expression-parse": "^3.0.0"
             }
-        },
-        "node_modules/verror": {
-            "version": "1.10.0",
-            "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-            "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-            "engines": [
-                "node >=0.6.0"
-            ],
-            "dependencies": {
-                "assert-plus": "^1.0.0",
-                "core-util-is": "1.0.2",
-                "extsprintf": "^1.2.0"
-            }
-        },
-        "node_modules/verror/node_modules/core-util-is": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-            "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
         },
         "node_modules/void-elements": {
             "version": "3.1.0",
@@ -5798,26 +5122,10 @@
                 }
             }
         },
-        "node_modules/xhr": {
-            "version": "2.6.0",
-            "resolved": "https://registry.npmjs.org/xhr/-/xhr-2.6.0.tgz",
-            "integrity": "sha512-/eCGLb5rxjx5e3mF1A7s+pLlR6CGyqWN91fv1JgER5mVWg1MZmlhBvy9kjcsOdRk8RrIujotWyJamfyrp+WIcA==",
-            "dependencies": {
-                "global": "~4.4.0",
-                "is-function": "^1.0.1",
-                "parse-headers": "^2.0.0",
-                "xtend": "^4.0.0"
-            }
-        },
-        "node_modules/xml-parse-from-string": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/xml-parse-from-string/-/xml-parse-from-string-1.0.1.tgz",
-            "integrity": "sha1-qQKekp09vN7RafPG4oI42VpdWig="
-        },
         "node_modules/xml2js": {
-            "version": "0.4.23",
-            "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
-            "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
+            "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
             "dependencies": {
                 "sax": ">=0.6.0",
                 "xmlbuilder": "~11.0.0"
@@ -5840,14 +5148,6 @@
             "integrity": "sha512-f9s+fUkX04BxQf+7mMWAp5zk61pciie+fFLC9hX9UVvCeJQfNHRHXpeo5MPcR0EUf57PYLdt+ZO4f3Ipk2oZUw==",
             "engines": {
                 "node": ">=0.1"
-            }
-        },
-        "node_modules/xtend": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-            "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-            "engines": {
-                "node": ">=0.4"
             }
         },
         "node_modules/yallist": {
@@ -5972,21 +5272,6 @@
                     "requires": {
                         "queue": "6.0.2"
                     }
-                },
-                "sharp": {
-                    "version": "0.31.3",
-                    "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.31.3.tgz",
-                    "integrity": "sha512-XcR4+FCLBFKw1bdB+GEhnUNXNXvnt0tDo4WsBsraKymuo/IAuPuCBVAL2wIkUw2r/dwFW5Q5+g66Kwl2dgDFVg==",
-                    "requires": {
-                        "color": "^4.2.3",
-                        "detect-libc": "^2.0.1",
-                        "node-addon-api": "^5.0.0",
-                        "prebuild-install": "^7.1.1",
-                        "semver": "^7.3.8",
-                        "simple-get": "^4.0.1",
-                        "tar-fs": "^2.1.1",
-                        "tunnel-agent": "^0.6.0"
-                    }
                 }
             }
         },
@@ -6039,9 +5324,9 @@
             }
         },
         "@azure/core-http": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@azure/core-http/-/core-http-3.0.0.tgz",
-            "integrity": "sha512-BxI2SlGFPPz6J1XyZNIVUf0QZLBKFX+ViFjKOkzqD18J1zOINIQ8JSBKKr+i+v8+MB6LacL6Nn/sP/TE13+s2Q==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/@azure/core-http/-/core-http-3.0.1.tgz",
+            "integrity": "sha512-A3x+um3cAPgQe42Lu7Iv/x8/fNjhL/nIoEfqFxfn30EyxK6zC13n+OUxzZBRC0IzQqssqIbt4INf5YG7lYYFtw==",
             "requires": {
                 "@azure/abort-controller": "^1.0.0",
                 "@azure/core-auth": "^1.3.0",
@@ -6056,7 +5341,7 @@
                 "tslib": "^2.2.0",
                 "tunnel": "^0.0.6",
                 "uuid": "^8.3.0",
-                "xml2js": "^0.4.19"
+                "xml2js": "^0.5.0"
             }
         },
         "@azure/core-lro": {
@@ -6384,17 +5669,6 @@
             "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
             "dev": true
         },
-        "ajv": {
-            "version": "6.12.6",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-            "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-            "requires": {
-                "fast-deep-equal": "^3.1.1",
-                "fast-json-stable-stringify": "^2.0.0",
-                "json-schema-traverse": "^0.4.1",
-                "uri-js": "^4.2.2"
-            }
-        },
         "ansi-colors": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
@@ -6459,7 +5733,8 @@
         "arrify": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-            "integrity": "sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA=="
+            "integrity": "sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==",
+            "dev": true
         },
         "asap": {
             "version": "2.0.6",
@@ -6467,24 +5742,11 @@
             "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
             "dev": true
         },
-        "asn1": {
-            "version": "0.2.6",
-            "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
-            "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
-            "requires": {
-                "safer-buffer": "~2.1.0"
-            }
-        },
         "assert-never": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/assert-never/-/assert-never-1.2.1.tgz",
             "integrity": "sha512-TaTivMB6pYI1kXwrFlEhLeGfOqoDNdTxjCdwRfFFkEA30Eu+k48W34nlok2EYWJfFFzqaEmichdNM7th6M5HNw==",
             "dev": true
-        },
-        "assert-plus": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-            "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
         },
         "assured": {
             "version": "1.0.15",
@@ -6505,16 +5767,6 @@
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
             "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
-        },
-        "aws-sign2": {
-            "version": "0.7.0",
-            "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-            "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
-        },
-        "aws4": {
-            "version": "1.11.0",
-            "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
-            "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
         },
         "axios": {
             "version": "1.3.5",
@@ -6572,23 +5824,10 @@
                 "bcp-47-match": "^1.0.0"
             }
         },
-        "bcrypt-pbkdf": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-            "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
-            "requires": {
-                "tweetnacl": "^0.14.3"
-            }
-        },
         "before-after-hook": {
             "version": "2.2.2",
             "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.2.tgz",
             "integrity": "sha512-3pZEU3NT5BFUo/AD5ERPWOgQOCZITni6iavr5AUw5AUwQjMlI0kzu5btnyD39AF0gUEsDPwJT+oY1ORBJijPjQ=="
-        },
-        "bignumber.js": {
-            "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-2.4.0.tgz",
-            "integrity": "sha1-g4qZLan51zfg9LLbC+YrsJ3Qxeg="
         },
         "binary-extensions": {
             "version": "2.2.0",
@@ -6614,11 +5853,6 @@
                 "inherits": "^2.0.4",
                 "readable-stream": "^3.4.0"
             }
-        },
-        "bmp-js": {
-            "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/bmp-js/-/bmp-js-0.0.1.tgz",
-            "integrity": "sha1-WtAUcJnROp84qnuZrx1ueGZu038="
         },
         "boolbase": {
             "version": "1.0.0",
@@ -6652,30 +5886,6 @@
                 "ieee754": "^1.1.13"
             }
         },
-        "buffer-alloc": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
-            "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
-            "requires": {
-                "buffer-alloc-unsafe": "^1.1.0",
-                "buffer-fill": "^1.0.0"
-            }
-        },
-        "buffer-alloc-unsafe": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
-            "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg=="
-        },
-        "buffer-equal": {
-            "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-0.0.1.tgz",
-            "integrity": "sha1-kbx0sR6kBbyRa8aqkI+q+ltKrEs="
-        },
-        "buffer-fill": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
-            "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw="
-        },
         "call-bind": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
@@ -6704,11 +5914,6 @@
                 "regex-escape": "^3.4.10",
                 "uc-first-array": "^1.1.10"
             }
-        },
-        "caseless": {
-            "version": "0.12.0",
-            "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-            "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
         },
         "chalk": {
             "version": "2.4.2",
@@ -6916,14 +6121,6 @@
             "resolved": "https://registry.npmjs.org/css-what/-/css-what-5.1.0.tgz",
             "integrity": "sha512-arSMRWIIFY0hV8pIxZMEfmMI47Wj3R/aWpZDDxWYCPEiOMv6tfOrnpDtgxBYPEQD4V0Y/958+1TdC3iWTFcUPw=="
         },
-        "dashdash": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-            "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-            "requires": {
-                "assert-plus": "^1.0.0"
-            }
-        },
         "debug": {
             "version": "4.3.4",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -7005,11 +6202,6 @@
                 "entities": "^2.0.0"
             }
         },
-        "dom-walk": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
-            "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w=="
-        },
         "domelementtype": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
@@ -7038,15 +6230,6 @@
             "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
             "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ=="
         },
-        "ecc-jsbn": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-            "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
-            "requires": {
-                "jsbn": "~0.1.0",
-                "safer-buffer": "^2.1.0"
-            }
-        },
         "ee-first": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -7062,13 +6245,14 @@
                 "jake": "^10.8.5"
             }
         },
-        "eleventy-favicon": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/eleventy-favicon/-/eleventy-favicon-1.1.3.tgz",
-            "integrity": "sha512-eA051s+frbtjlT/MMSoqo4ObAd8FLo//DxH2LdjHQFPqL1JJRz/tuQqJy+0x2qgvB18w2Hwtrcg6PI3NGRsv9w==",
+        "eleventy-plugin-gen-favicons": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/eleventy-plugin-gen-favicons/-/eleventy-plugin-gen-favicons-1.1.2.tgz",
+            "integrity": "sha512-DtxS3J+ujDVZ9oP5RTOTxwET2K7S7WEvQ7XE/S3TwM7uQR/NOqHibuZXyftutK22EU1UInQc2yP1JZ7mtnWJUQ==",
             "requires": {
-                "sharp": "^0.30.4",
-                "to-ico": "^1.1.5"
+                "fast-deep-equal": "^3.1.3",
+                "png-to-ico": "^2.1.8",
+                "sharp": "^0.31.3"
             }
         },
         "eleventy-plugin-nesting-toc": {
@@ -7160,11 +6344,6 @@
                 "is-symbol": "^1.0.2"
             }
         },
-        "es6-promise": {
-            "version": "3.3.1",
-            "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz",
-            "integrity": "sha1-oIzd6EzNvzTQJ6FFG8kdS80ophM="
-        },
         "escape-goat": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/escape-goat/-/escape-goat-3.0.0.tgz",
@@ -7201,20 +6380,10 @@
             "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
             "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="
         },
-        "exif-parser": {
-            "version": "0.1.12",
-            "resolved": "https://registry.npmjs.org/exif-parser/-/exif-parser-0.1.12.tgz",
-            "integrity": "sha1-WKnS1ywCwfbwKg70qRZicrd2CSI="
-        },
         "expand-template": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
             "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg=="
-        },
-        "extend": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-            "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
         },
         "extend-shallow": {
             "version": "2.0.1",
@@ -7223,11 +6392,6 @@
             "requires": {
                 "is-extendable": "^0.1.0"
             }
-        },
-        "extsprintf": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-            "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
         },
         "fast-deep-equal": {
             "version": "3.1.3",
@@ -7247,11 +6411,6 @@
                 "micromatch": "^4.0.4"
             }
         },
-        "fast-json-stable-stringify": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-            "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
-        },
         "fastq": {
             "version": "1.14.0",
             "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.14.0.tgz",
@@ -7260,11 +6419,6 @@
             "requires": {
                 "reusify": "^1.0.4"
             }
-        },
-        "file-type": {
-            "version": "3.9.0",
-            "resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
-            "integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek="
         },
         "filelist": {
             "version": "1.0.4",
@@ -7387,11 +6541,6 @@
                 "signal-exit": "^4.0.1"
             }
         },
-        "forever-agent": {
-            "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-            "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
-        },
         "form-data": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
@@ -7456,15 +6605,6 @@
                 "has-symbols": "^1.0.1"
             }
         },
-        "get-stream": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
-            "integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=",
-            "requires": {
-                "object-assign": "^4.0.1",
-                "pinkie-promise": "^2.0.0"
-            }
-        },
         "get-symbol-description": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
@@ -7473,14 +6613,6 @@
             "requires": {
                 "call-bind": "^1.0.2",
                 "get-intrinsic": "^1.1.1"
-            }
-        },
-        "getpass": {
-            "version": "0.1.7",
-            "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-            "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-            "requires": {
-                "assert-plus": "^1.0.0"
             }
         },
         "github-from-package": {
@@ -7533,15 +6665,6 @@
                 "is-glob": "^4.0.1"
             }
         },
-        "global": {
-            "version": "4.4.0",
-            "resolved": "https://registry.npmjs.org/global/-/global-4.4.0.tgz",
-            "integrity": "sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==",
-            "requires": {
-                "min-document": "^2.19.0",
-                "process": "^0.11.10"
-            }
-        },
         "graceful-fs": {
             "version": "4.2.11",
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -7576,20 +6699,6 @@
                 "source-map": "^0.6.1",
                 "uglify-js": "^3.1.4",
                 "wordwrap": "^1.0.0"
-            }
-        },
-        "har-schema": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-            "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
-        },
-        "har-validator": {
-            "version": "5.1.5",
-            "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
-            "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
-            "requires": {
-                "ajv": "^6.12.3",
-                "har-schema": "^2.0.0"
             }
         },
         "has": {
@@ -7680,25 +6789,10 @@
             "integrity": "sha512-TScO04soylRN9i/QdOdgZyhydXg9z6XdaGzEyOgDKycePeDeTT4KvigjBcI+tgfTlieLWauGORMq5F1eIDa+1w==",
             "dev": true
         },
-        "http-signature": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-            "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-            "requires": {
-                "assert-plus": "^1.0.0",
-                "jsprim": "^1.2.2",
-                "sshpk": "^1.7.0"
-            }
-        },
         "ieee754": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
             "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
-        },
-        "image-size": {
-            "version": "0.5.5",
-            "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.5.5.tgz",
-            "integrity": "sha1-Cd/Uq50g4p6xw+gLiZA3jfnjy5w="
         },
         "inflight": {
             "version": "1.0.6",
@@ -7729,11 +6823,6 @@
                 "has": "^1.0.3",
                 "side-channel": "^1.0.4"
             }
-        },
-        "ip-regex": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-1.0.3.tgz",
-            "integrity": "sha1-3FiQdvZZ9BnCIgOaMzFvHHOH7/0="
         },
         "is-alphabetical": {
             "version": "1.0.4",
@@ -7841,11 +6930,6 @@
             "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
             "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
         },
-        "is-function": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.2.tgz",
-            "integrity": "sha512-lw7DUp0aWXYg+CBCN+JKkcE0Q2RayZnSvnZBlwgxHBQhqt5pZNVy4Ri7H9GmmXkdu7LUthszM+Tor1u/2iBcpQ=="
-        },
         "is-glob": {
             "version": "4.0.3",
             "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -7927,11 +7011,6 @@
                 "has-symbols": "^1.0.2"
             }
         },
-        "is-typedarray": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-            "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
-        },
         "is-weakref": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
@@ -7951,11 +7030,6 @@
             "resolved": "https://registry.npmjs.org/iso-639-1/-/iso-639-1-2.1.15.tgz",
             "integrity": "sha512-7c7mBznZu2ktfvyT582E2msM+Udc1EjOyhVRE/0ZsjD9LBtWSm23h3PtiRh2a35XoUsTQQjJXaJzuLjXsOdFDg==",
             "dev": true
-        },
-        "isstream": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-            "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
         },
         "jackspeak": {
             "version": "2.0.3",
@@ -8029,46 +7103,6 @@
                 }
             }
         },
-        "jimp": {
-            "version": "0.2.28",
-            "resolved": "https://registry.npmjs.org/jimp/-/jimp-0.2.28.tgz",
-            "integrity": "sha512-9HT7DA279xkTlry2oG30s6AtOUglNiY2UdyYpj0yNI4/NBv8PmdNC0gcldgMU4HqvbUlrM3+v+6GaHnTkH23JQ==",
-            "requires": {
-                "bignumber.js": "^2.1.0",
-                "bmp-js": "0.0.3",
-                "es6-promise": "^3.0.2",
-                "exif-parser": "^0.1.9",
-                "file-type": "^3.1.0",
-                "jpeg-js": "^0.2.0",
-                "load-bmfont": "^1.2.3",
-                "mime": "^1.3.4",
-                "mkdirp": "0.5.1",
-                "pixelmatch": "^4.0.0",
-                "pngjs": "^3.0.0",
-                "read-chunk": "^1.0.1",
-                "request": "^2.65.0",
-                "stream-to-buffer": "^0.1.0",
-                "tinycolor2": "^1.1.2",
-                "url-regex": "^3.0.0"
-            },
-            "dependencies": {
-                "bmp-js": {
-                    "version": "0.0.3",
-                    "resolved": "https://registry.npmjs.org/bmp-js/-/bmp-js-0.0.3.tgz",
-                    "integrity": "sha1-ZBE+nHzxICs3btYHvzBibr5XsYo="
-                },
-                "jpeg-js": {
-                    "version": "0.2.0",
-                    "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.2.0.tgz",
-                    "integrity": "sha512-Ni9PffhJtYtdD7VwxH6V2MnievekGfUefosGCHadog0/jAevRu6HPjYeMHbUemn0IPE8d4wGa8UsOGsX+iKy2g=="
-                }
-            }
-        },
-        "jpeg-js": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.1.2.tgz",
-            "integrity": "sha512-CiRVjMKBUp6VYtGwzRjrdnro41yMwKGOWdP9ATXqmixdz2n7KHNwdqthTYSSbOKj/Ha79Gct1sA8ZQpse55TYA=="
-        },
         "js-stringify": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/js-stringify/-/js-stringify-1.0.2.tgz",
@@ -8084,42 +7118,11 @@
                 "esprima": "^4.0.0"
             }
         },
-        "jsbn": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-            "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
-        },
         "json-parse-better-errors": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
             "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
             "dev": true
-        },
-        "json-schema": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
-            "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
-        },
-        "json-schema-traverse": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
-        },
-        "json-stringify-safe": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-            "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
-        },
-        "jsprim": {
-            "version": "1.4.2",
-            "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
-            "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
-            "requires": {
-                "assert-plus": "1.0.0",
-                "extsprintf": "1.3.0",
-                "json-schema": "0.4.0",
-                "verror": "1.10.0"
-            }
         },
         "jstransformer": {
             "version": "1.0.0",
@@ -8197,21 +7200,6 @@
             "resolved": "https://registry.npmjs.org/list-to-array/-/list-to-array-1.1.0.tgz",
             "integrity": "sha512-+dAZZ2mM+/m+vY9ezfoueVvrgnHIGi5FvgSymbIgJOFwiznWyA59mav95L+Mc6xPtL3s9gm5eNTlNtxJLbNM1g==",
             "dev": true
-        },
-        "load-bmfont": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/load-bmfont/-/load-bmfont-1.4.1.tgz",
-            "integrity": "sha512-8UyQoYmdRDy81Brz6aLAUhfZLwr5zV0L3taTQ4hju7m6biuwiWiJXjPhBJxbUQJA8PrkvJ/7Enqmwk2sM14soA==",
-            "requires": {
-                "buffer-equal": "0.0.1",
-                "mime": "^1.3.4",
-                "parse-bmfont-ascii": "^1.0.3",
-                "parse-bmfont-binary": "^1.0.5",
-                "parse-bmfont-xml": "^1.1.4",
-                "phin": "^2.9.1",
-                "xhr": "^2.0.1",
-                "xtend": "^4.0.0"
-            }
         },
         "load-json-file": {
             "version": "4.0.0",
@@ -8394,11 +7382,6 @@
                 "picomatch": "^2.3.1"
             }
         },
-        "mime": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
-            "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ=="
-        },
         "mime-db": {
             "version": "1.51.0",
             "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.51.0.tgz",
@@ -8416,14 +7399,6 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
             "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ=="
-        },
-        "min-document": {
-            "version": "2.19.0",
-            "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
-            "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
-            "requires": {
-                "dom-walk": "^0.1.0"
-            }
         },
         "minimatch": {
             "version": "3.1.2",
@@ -8453,18 +7428,12 @@
             "integrity": "sha512-7NO5s6n10TIV96d4g2uDpG7ZDpIhMh0QNfGdJw/W47JswFcosz457wqz/b5sAKvl12sxINGFCn80NZHKwxQEXA=="
         },
         "mkdirp": {
-            "version": "0.5.1",
-            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-            "integrity": "sha512-SknJC52obPfGQPnjIkXbmA6+5H15E+fR+E4iR2oQ3zzCLbd7/ONua69R/Gw7AgkTLsRG+r5fzksYwWe1AgTyWA==",
+            "version": "0.5.6",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+            "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+            "dev": true,
             "requires": {
-                "minimist": "0.0.8"
-            },
-            "dependencies": {
-                "minimist": {
-                    "version": "0.0.8",
-                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-                    "integrity": "sha512-miQKw5Hv4NS1Psg2517mV4e4dYNaO3++hjAvLOAzKqZ61rH8NS1SK+vbfBWZ5PY/Me/bEWhUwqMghEW5Fb9T7Q=="
-                }
+                "minimist": "^1.2.6"
             }
         },
         "mkdirp-classic": {
@@ -8739,9 +7708,9 @@
             }
         },
         "nunjucks": {
-            "version": "3.2.3",
-            "resolved": "https://registry.npmjs.org/nunjucks/-/nunjucks-3.2.3.tgz",
-            "integrity": "sha512-psb6xjLj47+fE76JdZwskvwG4MYsQKXUtMsPh6U0YMvmyjRtKRFcxnlXGWglNybtNTNVmGdp94K62/+NjF5FDQ==",
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/nunjucks/-/nunjucks-3.2.4.tgz",
+            "integrity": "sha512-26XRV6BhkgK0VOxfbU5cQI+ICFUtMLixv1noZn1tGU38kQH5A5nmmbk/O45xdyBhD1esk47nKrY0mvQpZIhRjQ==",
             "dev": true,
             "requires": {
                 "a-sync-waterfall": "^1.0.0",
@@ -8749,15 +7718,11 @@
                 "commander": "^5.1.0"
             }
         },
-        "oauth-sign": {
-            "version": "0.9.0",
-            "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-            "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
-        },
         "object-assign": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-            "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+            "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+            "dev": true
         },
         "object-inspect": {
             "version": "1.12.0",
@@ -8831,30 +7796,6 @@
                 "no-case": "^2.2.0"
             }
         },
-        "parse-bmfont-ascii": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/parse-bmfont-ascii/-/parse-bmfont-ascii-1.0.6.tgz",
-            "integrity": "sha1-Eaw8P/WPfCAgqyJ2kHkQjU36AoU="
-        },
-        "parse-bmfont-binary": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/parse-bmfont-binary/-/parse-bmfont-binary-1.0.6.tgz",
-            "integrity": "sha1-0Di0dtPp3Z2x4RoLDlOiJ5K2kAY="
-        },
-        "parse-bmfont-xml": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/parse-bmfont-xml/-/parse-bmfont-xml-1.1.4.tgz",
-            "integrity": "sha512-bjnliEOmGv3y1aMEfREMBJ9tfL3WR0i0CKPj61DnSLaoxWR3nLrsQrEbCId/8rF4NyRF0cCqisSVXyQYWM+mCQ==",
-            "requires": {
-                "xml-parse-from-string": "^1.0.0",
-                "xml2js": "^0.4.5"
-            }
-        },
-        "parse-headers": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.5.tgz",
-            "integrity": "sha512-ft3iAoLOB/MlwbNXgzy43SWGP6sQki2jQvAyBg/zDFAgr9bfNWZIUj42Kw2eJIl8kEi4PbgE6U1Zau/HwI75HA=="
-        },
         "parse-json": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
@@ -8863,14 +7804,6 @@
             "requires": {
                 "error-ex": "^1.3.1",
                 "json-parse-better-errors": "^1.0.1"
-            }
-        },
-        "parse-png": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/parse-png/-/parse-png-1.1.2.tgz",
-            "integrity": "sha1-9cKtfHmTSQmGAgooTBmu5FlxH/I=",
-            "requires": {
-                "pngjs": "^3.2.0"
             }
         },
         "parse-srcset": {
@@ -8945,16 +7878,6 @@
                 "pify": "^3.0.0"
             }
         },
-        "performance-now": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-            "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
-        },
-        "phin": {
-            "version": "2.9.3",
-            "resolved": "https://registry.npmjs.org/phin/-/phin-2.9.3.tgz",
-            "integrity": "sha512-CzFr90qM24ju5f88quFC/6qohjC144rehe5n6DH900lgXmUe86+xCKc10ev56gRKC4/BkHUoG4uSiQgBiIXwDA=="
-        },
         "picomatch": {
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
@@ -8973,27 +7896,6 @@
             "integrity": "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==",
             "dev": true
         },
-        "pinkie": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-            "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
-        },
-        "pinkie-promise": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-            "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-            "requires": {
-                "pinkie": "^2.0.0"
-            }
-        },
-        "pixelmatch": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/pixelmatch/-/pixelmatch-4.0.2.tgz",
-            "integrity": "sha1-j0fc7FARtHe2fbA8JDvB8wheiFQ=",
-            "requires": {
-                "pngjs": "^3.0.0"
-            }
-        },
         "please-upgrade-node": {
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz",
@@ -9003,10 +7905,27 @@
                 "semver-compare": "^1.0.0"
             }
         },
+        "png-to-ico": {
+            "version": "2.1.8",
+            "resolved": "https://registry.npmjs.org/png-to-ico/-/png-to-ico-2.1.8.tgz",
+            "integrity": "sha512-Nf+IIn/cZ/DIZVdGveJp86NG5uNib1ZXMiDd/8x32HCTeKSvgpyg6D/6tUBn1QO/zybzoMK0/mc3QRgAyXdv9w==",
+            "requires": {
+                "@types/node": "^17.0.36",
+                "minimist": "^1.2.6",
+                "pngjs": "^6.0.0"
+            },
+            "dependencies": {
+                "@types/node": {
+                    "version": "17.0.45",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
+                    "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw=="
+                }
+            }
+        },
         "pngjs": {
-            "version": "3.4.0",
-            "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-3.4.0.tgz",
-            "integrity": "sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w=="
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-6.0.0.tgz",
+            "integrity": "sha512-TRzzuFRRmEoSW/p1KVAmiOgPco2Irlah+bGFCeNfJXxxYGwSw7YwAOAcd7X28K/m5bjBWKsC29KyoMfHbypayg=="
         },
         "posthtml": {
             "version": "0.16.6",
@@ -9120,11 +8039,6 @@
             "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
             "integrity": "sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw==",
             "dev": true
-        },
-        "psl": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
-            "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
         },
         "pug": {
             "version": "3.0.2",
@@ -9259,11 +8173,6 @@
                 "once": "^1.3.1"
             }
         },
-        "punycode": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-            "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
-        },
         "queue": {
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/queue/-/queue-6.0.2.tgz",
@@ -9288,11 +8197,6 @@
                 "minimist": "^1.2.0",
                 "strip-json-comments": "~2.0.1"
             }
-        },
-        "read-chunk": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/read-chunk/-/read-chunk-1.0.1.tgz",
-            "integrity": "sha1-X2jKswfmY/GZk1J9m1icrORmEZQ="
         },
         "read-dir-and-stat": {
             "version": "1.0.8",
@@ -9369,77 +8273,6 @@
             "integrity": "sha512-G08Dxvm4iDN3MLM0EsP62EDV9IuhXPR6blNz6Utcp7zyV3tr4HVNINt6MpaRWbxoOHT3Q7YN2P+jaHX8vUbgog==",
             "dev": true
         },
-        "request": {
-            "version": "2.88.2",
-            "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
-            "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
-            "requires": {
-                "aws-sign2": "~0.7.0",
-                "aws4": "^1.8.0",
-                "caseless": "~0.12.0",
-                "combined-stream": "~1.0.6",
-                "extend": "~3.0.2",
-                "forever-agent": "~0.6.1",
-                "form-data": "~2.3.2",
-                "har-validator": "~5.1.3",
-                "http-signature": "~1.2.0",
-                "is-typedarray": "~1.0.0",
-                "isstream": "~0.1.2",
-                "json-stringify-safe": "~5.0.1",
-                "mime-types": "~2.1.19",
-                "oauth-sign": "~0.9.0",
-                "performance-now": "^2.1.0",
-                "qs": "~6.5.2",
-                "safe-buffer": "^5.1.2",
-                "tough-cookie": "~2.5.0",
-                "tunnel-agent": "^0.6.0",
-                "uuid": "^3.3.2"
-            },
-            "dependencies": {
-                "form-data": {
-                    "version": "2.3.3",
-                    "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-                    "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-                    "requires": {
-                        "asynckit": "^0.4.0",
-                        "combined-stream": "^1.0.6",
-                        "mime-types": "^2.1.12"
-                    }
-                },
-                "qs": {
-                    "version": "6.5.3",
-                    "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
-                    "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA=="
-                },
-                "tough-cookie": {
-                    "version": "2.5.0",
-                    "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
-                    "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
-                    "requires": {
-                        "psl": "^1.1.28",
-                        "punycode": "^2.1.1"
-                    }
-                },
-                "uuid": {
-                    "version": "3.4.0",
-                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-                    "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
-                }
-            }
-        },
-        "resize-img": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/resize-img/-/resize-img-1.1.2.tgz",
-            "integrity": "sha512-/4nKUmuNPuM6gYTWad136ica81baOVjpesgv8FGaIvP0KWcbCWahOWBKaM4tFoM+aVcSA+qQDg28pcnIzFRpJw==",
-            "requires": {
-                "bmp-js": "0.0.1",
-                "file-type": "^3.8.0",
-                "get-stream": "^2.0.0",
-                "jimp": "^0.2.21",
-                "jpeg-js": "^0.1.1",
-                "parse-png": "^1.1.1"
-            }
-        },
         "resolve": {
             "version": "1.22.0",
             "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
@@ -9495,11 +8328,6 @@
             "version": "5.2.1",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
             "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
-        },
-        "safer-buffer": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
         },
         "same-time": {
             "version": "2.3.5",
@@ -9577,15 +8405,15 @@
             "dev": true
         },
         "sharp": {
-            "version": "0.30.7",
-            "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.30.7.tgz",
-            "integrity": "sha512-G+MY2YW33jgflKPTXXptVO28HvNOo9G3j0MybYAHeEmby+QuD2U98dT6ueht9cv/XDqZspSpIhoSW+BAKJ7Hig==",
+            "version": "0.31.3",
+            "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.31.3.tgz",
+            "integrity": "sha512-XcR4+FCLBFKw1bdB+GEhnUNXNXvnt0tDo4WsBsraKymuo/IAuPuCBVAL2wIkUw2r/dwFW5Q5+g66Kwl2dgDFVg==",
             "requires": {
                 "color": "^4.2.3",
                 "detect-libc": "^2.0.1",
                 "node-addon-api": "^5.0.0",
                 "prebuild-install": "^7.1.1",
-                "semver": "^7.3.7",
+                "semver": "^7.3.8",
                 "simple-get": "^4.0.1",
                 "tar-fs": "^2.1.1",
                 "tunnel-agent": "^0.6.0"
@@ -9744,22 +8572,6 @@
             "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
             "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
         },
-        "sshpk": {
-            "version": "1.17.0",
-            "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.17.0.tgz",
-            "integrity": "sha512-/9HIEs1ZXGhSPE8X6Ccm7Nam1z8KcoCqPdI7ecm1N33EzAetWahvQWVqLZtaZQ+IDKX4IyA2o0gBzqIMkAagHQ==",
-            "requires": {
-                "asn1": "~0.2.3",
-                "assert-plus": "^1.0.0",
-                "bcrypt-pbkdf": "^1.0.0",
-                "dashdash": "^1.12.0",
-                "ecc-jsbn": "~0.1.1",
-                "getpass": "^0.1.1",
-                "jsbn": "~0.1.0",
-                "safer-buffer": "^2.0.2",
-                "tweetnacl": "~0.14.0"
-            }
-        },
         "ssri": {
             "version": "8.0.1",
             "resolved": "https://registry.npmjs.org/ssri/-/ssri-8.0.1.tgz",
@@ -9774,19 +8586,6 @@
             "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
             "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
             "dev": true
-        },
-        "stream-to": {
-            "version": "0.2.2",
-            "resolved": "https://registry.npmjs.org/stream-to/-/stream-to-0.2.2.tgz",
-            "integrity": "sha1-hDBgmNhf25kLn6MAsbPM9V6O8B0="
-        },
-        "stream-to-buffer": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/stream-to-buffer/-/stream-to-buffer-0.1.0.tgz",
-            "integrity": "sha1-JnmdkDqyAlyb1VCsRxcbAPjdgKk=",
-            "requires": {
-                "stream-to": "~0.2.0"
-            }
         },
         "string_decoder": {
             "version": "1.3.0",
@@ -9899,28 +8698,11 @@
                 "readable-stream": "^3.1.1"
             }
         },
-        "tinycolor2": {
-            "version": "1.4.2",
-            "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.4.2.tgz",
-            "integrity": "sha512-vJhccZPs965sV/L2sU4oRQVAos0pQXwsvTLkWYdqJ+a8Q5kPFzJTuOFwy7UniPli44NKQGAglksjvOcpo95aZA=="
-        },
         "to-fast-properties": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
             "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
             "dev": true
-        },
-        "to-ico": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/to-ico/-/to-ico-1.1.5.tgz",
-            "integrity": "sha512-5kIh7m7bkIlqIESEZkL8gAMMzucXKfPe3hX2FoDY5HEAfD9OJU+Qh9b6Enp74w0qRcxVT5ejss66PHKqc3AVkg==",
-            "requires": {
-                "arrify": "^1.0.1",
-                "buffer-alloc": "^1.1.0",
-                "image-size": "^0.5.0",
-                "parse-png": "^1.0.0",
-                "resize-img": "^1.1.0"
-            }
         },
         "to-regex-range": {
             "version": "5.0.1",
@@ -9959,11 +8741,6 @@
             "requires": {
                 "safe-buffer": "^5.0.1"
             }
-        },
-        "tweetnacl": {
-            "version": "0.14.5",
-            "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-            "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
         },
         "typpy": {
             "version": "2.3.13",
@@ -10026,22 +8803,6 @@
             "integrity": "sha512-WRbjgmYzgXkCV7zNVpy5YgrHgbBv126rMALQQMrmzOVC4GM2waQ9x7xtm8VU+1yF2kWyPzI9zbZ48n4vSxwfSA==",
             "dev": true
         },
-        "uri-js": {
-            "version": "4.4.1",
-            "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
-            "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-            "requires": {
-                "punycode": "^2.1.0"
-            }
-        },
-        "url-regex": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/url-regex/-/url-regex-3.2.0.tgz",
-            "integrity": "sha512-dQ9cJzMou5OKr6ZzfvwJkCq3rC72PNXhqz0v3EIhF4a3Np+ujr100AhUx2cKx5ei3iymoJpJrPB3sVSEMdqAeg==",
-            "requires": {
-                "ip-regex": "^1.0.1"
-            }
-        },
         "util-deprecate": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -10065,23 +8826,6 @@
             "requires": {
                 "spdx-correct": "^3.0.0",
                 "spdx-expression-parse": "^3.0.0"
-            }
-        },
-        "verror": {
-            "version": "1.10.0",
-            "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-            "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-            "requires": {
-                "assert-plus": "^1.0.0",
-                "core-util-is": "1.0.2",
-                "extsprintf": "^1.2.0"
-            },
-            "dependencies": {
-                "core-util-is": {
-                    "version": "1.0.2",
-                    "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                    "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
-                }
             }
         },
         "void-elements": {
@@ -10232,26 +8976,10 @@
             "dev": true,
             "requires": {}
         },
-        "xhr": {
-            "version": "2.6.0",
-            "resolved": "https://registry.npmjs.org/xhr/-/xhr-2.6.0.tgz",
-            "integrity": "sha512-/eCGLb5rxjx5e3mF1A7s+pLlR6CGyqWN91fv1JgER5mVWg1MZmlhBvy9kjcsOdRk8RrIujotWyJamfyrp+WIcA==",
-            "requires": {
-                "global": "~4.4.0",
-                "is-function": "^1.0.1",
-                "parse-headers": "^2.0.0",
-                "xtend": "^4.0.0"
-            }
-        },
-        "xml-parse-from-string": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/xml-parse-from-string/-/xml-parse-from-string-1.0.1.tgz",
-            "integrity": "sha1-qQKekp09vN7RafPG4oI42VpdWig="
-        },
         "xml2js": {
-            "version": "0.4.23",
-            "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
-            "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
+            "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
             "requires": {
                 "sax": ">=0.6.0",
                 "xmlbuilder": "~11.0.0"
@@ -10266,11 +8994,6 @@
             "version": "0.1.31",
             "resolved": "https://registry.npmjs.org/xmldom-sre/-/xmldom-sre-0.1.31.tgz",
             "integrity": "sha512-f9s+fUkX04BxQf+7mMWAp5zk61pciie+fFLC9hX9UVvCeJQfNHRHXpeo5MPcR0EUf57PYLdt+ZO4f3Ipk2oZUw=="
-        },
-        "xtend": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-            "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
         },
         "yallist": {
             "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
         "@sindresorhus/slugify": "^1.1.0",
         "axios": "^1.2.2",
         "dotenv": "^16.0.3",
-        "eleventy-favicon": "^1.1.2",
+        "eleventy-plugin-gen-favicons": "^1.1.2",
         "eleventy-plugin-nesting-toc": "^1.3.0",
         "fs-file-tree": "^1.1.1",
         "glob": "^10.2.1",

--- a/src/site/_includes/components/pageheader.njk
+++ b/src/site/_includes/components/pageheader.njk
@@ -32,7 +32,7 @@
 <link href="{{style}}" rel="stylesheet">
 {%- endfor -%}
 
-{% favicon './src/site/favicon.svg' %}
+{% favicons './src/site/favicon.svg', appleIconBgColor='#123' %}
 
 {% if metatags %}
     {% for name, content in metatags %}


### PR DESCRIPTION
Closing #148 in favour of this : I needed to keep the branch seperate so i can continue working on other things.

Old comment

This has been bothering me for some time in this otherwise awesome project this one npm plugin was generating audit findings.
```
npm WARN deprecated har-validator@5.1.5: this library is no longer supported
npm WARN deprecated uuid@3.4.0: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
npm WARN deprecated mkdirp@0.5.1: Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)
npm WARN deprecated request@2.88.2: request has been deprecated, see https://github.com/request/request/issues/3142

added 555 packages, and audited 556 packages in 12s

98 packages are looking for funding
  run `npm fund` for details

14 vulnerabilities (6 moderate, 5 high, 3 critical)

To address issues that do not require attention, run:
  npm audit fix

Some issues need review, and may require choosing
a different dependency.

Run `npm audit` for details.
```

Funny enough someone has reported these findings https://github.com/atomrc/eleventy-favicon/issues/1 and there was a drop in solution indirectly listed right there in the comments.

This pull request replaces the favicon plugin with favicons.
Additionally it seems some other dependencies got upgraded. I am running this updated code on my portal and everything seems to be doing just fine.

current status

```
$ npm audit                
found 0 vulnerabilities
```