### PR TITLE
Fix sorting order for numeric strings

### DIFF
--- a/src/helpers/filetreeUtils.js
+++ b/src/helpers/filetreeUtils.js
@@ -24,6 +24,17 @@ const sortTree = (unsorted) => {
         return -1;
       }
 
+      //Regular expression that extracts any initial decimal number
+      const aNum = parseFloat(a.match(/^\d+(\.\d+)?/));
+      const bNum = parseFloat(b.match(/^\d+(\.\d+)?/));
+
+      const a_is_num = !isNaN(aNum);
+      const b_is_num = !isNaN(bNum);
+
+      if (a_is_num && b_is_num && aNum != bNum) {
+        return aNum - bNum; //Fast comparison between numbers
+      }
+
       if (a.toLowerCase() > b.toLowerCase()) {
         return 1;
       }


### PR DESCRIPTION
I have noticed that since strings are compared using alphabetical order, if they start with a number they won't be compared correctly. For example, '10' will be placed before '2' in the sorted results. So, I tried to fix this problem using a regular expression that extracts the numeric portion at the beginning of each string (if it's possible) and performs a numerical comparison.
See an example below.

![image](https://github.com/oleeskild/digitalgarden/assets/75183735/f7f0c627-8d7c-459d-b8d8-33f3c57ba64d)
