### PR TITLE
fix: 💄 question/help/faq callout color to match obsidian

### DIFF
--- a/src/site/styles/obsidian-base.scss
+++ b/src/site/styles/obsidian-base.scss
@@ -5829,7 +5829,7 @@ body {
   .callout[data-callout="question"],
   .callout[data-callout="help"],
   .callout[data-callout="faq"] {
-    --callout-color: 100, 221, 23;
+    --callout-color: 224, 172, 0;
     --callout-icon: help-circle;
   }
   .callout[data-callout="warning"],


### PR DESCRIPTION
This PR tweaks the callout color for question/help/faq type to match the obsidian standard yellow.