### PR TITLE
Adds user selected language in <html lang="">

### DIFF
--- a/src/site/404.njk
+++ b/src/site/404.njk
@@ -1,6 +1,6 @@
 
 <!DOCTYPE html>
-<html lang="en">
+<html lang="{{ meta.mainLanguage }}">
     <head>
         <title>Nothing here</title>
         <link href="/styles/digital-garden-base.css" rel="stylesheet">

--- a/src/site/_data/meta.js
+++ b/src/site/_data/meta.js
@@ -48,7 +48,7 @@ module.exports = async (data) => {
     bodyClasses.push("backlinks-note-icon");
     noteIconsSettings.backlinks = true;
   }
-  if(styleSettingsCss){
+  if (styleSettingsCss) {
     bodyClasses.push("css-settings-manager");
   }
 
@@ -66,6 +66,7 @@ module.exports = async (data) => {
     timestampSettings,
     baseTheme: process.env.BASE_THEME || "dark",
     siteName: process.env.SITE_NAME_HEADER || "Digital Garden",
+    mainLanguage: process.env.SITE_MAIN_LANGUAGE || "en",
     siteBaseUrl: baseUrl,
     styleSettingsCss,
     buildDate: new Date(),

--- a/src/site/_includes/layouts/index.njk
+++ b/src/site/_includes/layouts/index.njk
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="{{ meta.mainLanguage }}">
   <head>
     <title>{% if title %}{{ title }}{% else %}{{ page.fileSlug }}{% endif %}</title>
     {%include "components/pageheader.njk"%}

--- a/src/site/_includes/layouts/note.njk
+++ b/src/site/_includes/layouts/note.njk
@@ -2,7 +2,7 @@
 permalink: "notes/{{ page.fileSlug | slugify }}/"
 ---
 <!DOCTYPE html>
-<html lang="en">
+<html lang="{{ meta.mainLanguage }}">
   <head>
     <title>{% if title %}{{ title }}{% else %}{{ page.fileSlug }}{% endif %}</title>
     {%include "components/pageheader.njk"%}


### PR DESCRIPTION
Must be seen in connection with https://github.com/oleeskild/obsidian-digital-garden/pull/473 and https://github.com/oleeskild/obsidian-digital-garden/issues/472

This commit uses the SITE_MAIN_LANGUAGE set in the .env for all lang attributes in html elements. If no SITE_MAIN_LANGUAGE is set, it defaults to `<html lang="en">`.

This is part of my first pull request (and I have zero Obsidian plugin development experience), so please be very critical of my work.