### PR TITLE
Replace H1 with Span in the Navbar

### DIFF
--- a/src/site/_includes/components/navbar.njk
+++ b/src/site/_includes/components/navbar.njk
@@ -2,7 +2,7 @@
     <nav class="navbar">
         <div class="navbar-inner">
             <a href="/" style="text-decoration: none;">
-                <h1 style="margin: 15px !important;">{{meta.siteName}}</h1>
+                <span style="margin: 15px" !important; font-size="1.6em";>{{meta.siteName}}</span>
             </a>
         </div>
         {% if settings.dgEnableSearch === true%}


### PR DESCRIPTION
a. Cause: Duplicate h1 in code
-  src/site/_includes/components/navbar.njk usa
-  src/site/_includes/layouts/note.njk usa

b. Solution: Change h1 with span in navbar

c. todo: use the appropriate style class