### PR TITLE
in case there are links in the callout title

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -355,7 +355,7 @@ module.exports = function (eleventyConfig) {
         let calloutMetaData = "";
         let isCollapsable;
         let isCollapsed;
-        const calloutMeta = /\[!([\w-]*)\|?(\s?.*)\](\+|\-){0,1}(\s?.*)/;
+        const calloutMeta = /\[!([\w-]*)\|?(\s?[^\]]*)\](\+|\-){0,1}(\s?.*)/;
         if (!content.match(calloutMeta)) {
           continue;
         }


### PR DESCRIPTION
for example:
> [!bug] Something [oleeskild/digitalgarden](https://github.com/oleeskild/digitalgarden)

function (metaInfoMatch, callout, metaData, collapse, title)
results in: > 
metaInfoMatch: "[!bug] Something [oleeskild/digitalgarden](https://github.com/oleeskild/digitalgarden)" 
callout: "bug" 
metaData: "] Something [oleeskild/digitalgarden" 
collapse: undefined 
title: "(https://github.com/oleeskild/digitalgarden)"

I'm not sure this RegExp fits other cases. 😢