### PR TITLE
Update and rename build.yml to deploy.yml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,3 +28,8 @@ jobs:
         cache: 'npm'
     - run: npm install
     - run: npm run build --if-present
+    - name: Deploy
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./dist


### PR DESCRIPTION
This adds a GitHub Pages deployment stage to the build workflow, which I thus renamed to “deploy.yml”

I’m not sure if you’re interested in adding this or not, but I figured it would be worth proposing the change anyway.

Note: I have _not_ actually tested this, because the repo I use for my own live DG site is private and therefore won’t let me use Pages for free. So if you decide to incorporate this change, please keep that in mind — there might be a missing parameter or a typo or something. Therefore I have marked this as a draft. 

I’m not sure if I’ll use GH Pages myself, but if I do test this myself I’ll update the PR. Otherwise it’s there in case you’re interested in testing and merging it.

Thanks for the awesome repository and great documentation! If I get confident enough in my own site and add a little more content I might make a PR to add it to the list, but I’m shy… 🙈 