### PR TITLE
Check for ELEVENTY_ENV for minifier

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -495,6 +495,8 @@ module.exports = function (eleventyConfig) {
         useShortDoctype: true,
         removeComments: true,
         collapseWhitespace: true,
+        conservativeCollapse: true,
+        preserveLineBreaks: true,
         minifyCSS: true,
         minifyJS: true,
         keepClosingSlash: true,

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -487,7 +487,7 @@ module.exports = function (eleventyConfig) {
 
   eleventyConfig.addTransform("htmlMinifier", (content, outputPath) => {
     if (
-      process.env.NODE_ENV === "production" &&
+      (process.env.NODE_ENV === "production" || process.env.ELEVENTY_ENV === "prod") &&
       outputPath &&
       outputPath.endsWith(".html")
     ) {


### PR DESCRIPTION
`package.json` command `cross-env ELEVENTY_ENV=prod NODE_OPTIONS=--max-old-space-size=4096 eleventy` doesn't minify HTML because the config file only checks for `NODE_ENV`.

Also turned on `conservativeCollapse` and `preserveLineBreaks`, which will collapse whitespace to just 1 space or 1 newline instead of removing it entirely. This fixes an issue where mathjax blocks would not have spaces between text.