### PR TITLE
Fix sidebar overlap scrollbar

### DIFF
--- a/src/site/styles/digital-garden-base.scss
+++ b/src/site/styles/digital-garden-base.scss
@@ -64,7 +64,7 @@ ul.task-list {
 .sidebar {
     position: fixed;
     top: 75px;
-    right: 0;
+    right: 17px;
     height: 100%;
     min-width: 25px;
     display: flex;


### PR DESCRIPTION
The sidebar was overlapping the scrollbar of my browser (tested with Firefox and Brave). Therefore the scrollbar was not useable if there was a element in the sidebar.

This PR fixes it by moving the sidebar to the left by 17px (that's a typical size of the modern browsers).
