### PR TITLE
Fix Timestamp Parsing Error that renders Invalid Datetime

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -517,9 +517,13 @@ module.exports = function (eleventyConfig) {
 
 
   eleventyConfig.addFilter("dateToZulu", function (date) {
-    if (!date) return "";
-    return new Date(date).toISOString("dd-MM-yyyyTHH:mm:ssZ");
+    try {
+      return new Date(date).toISOString("dd-MM-yyyyTHH:mm:ssZ");
+    } catch {
+      return "";
+    }
   });
+  
   eleventyConfig.addFilter("jsonify", function (variable) {
     return JSON.stringify(variable) || '""';
   });

--- a/src/site/_includes/components/timestamps.njk
+++ b/src/site/_includes/components/timestamps.njk
@@ -1,7 +1,17 @@
 <script src=" https://fastly.jsdelivr.net/npm/luxon@3.2.1/build/global/luxon.min.js "></script>
 <script defer>
-    TIMESTAMP_FORMAT = "{{meta.timestampSettings.timestampFormat}}";
-    document.querySelectorAll('.human-date').forEach(function (el) {
-        el.innerHTML = luxon.DateTime.fromISO(el.getAttribute('data-date') || el.innerText).toFormat(TIMESTAMP_FORMAT);
-      });
+  TIMESTAMP_FORMAT = "{{meta.timestampSettings.timestampFormat}}";
+  document.querySelectorAll('.human-date').forEach(function (el) {
+    date = el.getAttribute('data-date') || el.innerText
+    parsed_date = luxon.DateTime.fromISO(date)
+    if (parsed_date.invalid != null){
+      // Date cannot be parsed
+      parsed_date = luxon.DateTime.fromSQL(date)
+    }
+    if (parsed_date.invalid != null){
+      // Date still cannot be parsed
+      parsed_date = luxon.DateTime.fromHTML(date)
+    }
+    el.innerHTML = parsed_date.toFormat(TIMESTAMP_FORMAT);
+  })
 </script>

--- a/src/site/sitemap.njk
+++ b/src/site/sitemap.njk
@@ -7,7 +7,7 @@ eleventyExcludeFromCollections: true
     {% for page in collections.all %}
         <url>
             <loc>{{ meta.siteBaseUrl }}{{ page.url | url }}</loc>
-            <lastmod>{{ page.date.toISOString() }}</lastmod>
+            <lastmod>{{ page.date | dateToZulu }}</lastmod>
         </url>
     {% endfor %}
 </urlset>


### PR DESCRIPTION
Fixes issue #206 
1. Updated `dateToZulu` filter to return `""` whenever the string is invalid 
2. added fallback timestamp parsing functions from luxon when the default method `fromISO()` raises an error
3. Update sitemap to also use `dateToZulu` filter 
