### PR TITLE
Cleanup dist before build

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "description": "",
     "main": "index.js",
     "scripts": {
+        "prebuild": "rm -rf dist",
         "start": "npm-run-all get-theme build:sass --parallel watch:*",
         "watch:sass": "sass --watch src/site/styles:dist/styles",
         "watch:eleventy": "cross-env ELEVENTY_ENV=dev eleventy --serve",


### PR DESCRIPTION
Currently, when a note is moved or renamed, the old file is not deleted. Therefore I recommend to do a cleanup before the build.

Executing `npm run build` executes `prebuild` as the first step.