### PR TITLE
Update to ignore a version of eleventy-plugin-rss that is too new.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,4 +12,7 @@ updates:
     ignore:
       - dependency-name: "@sindresorhus/slugify"
         # For slugify, ignore all updates.
+      - dependency-name: "@11ty/eleventy-plugin-rss"
+        versions [ "^1.2.0" ]
+      
         


### PR DESCRIPTION
From: https://www.11ty.dev/docs/plugins/rss/#installation v2 of this this plugin requires Eleventy v3.0 or newer. v1 of this plugin is compatible with Eleventy 0.11 or newer.

This change tells dependabot not to go over v1.2.0