### PR TITLE
fix(seo): meta-tags

### DIFF
--- a/src/site/_includes/components/pageheader.njk
+++ b/src/site/_includes/components/pageheader.njk
@@ -1,4 +1,15 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+{% if metatags %}
+    {% for name, content in metatags %}
+        {% if name.includes("og") %}
+          <meta property="{{ name }}" content="{{ content }}">
+        {% else %}
+          <meta name="{{ name }}" content="{{ content }}">
+        {% endif %}
+    {% endfor %}
+{% endif %}
+
 <script async type="module">
     import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs';
 </script>
@@ -29,12 +40,6 @@
 {%- endfor -%}
 
 {% favicons './src/site/favicon.svg', appleIconBgColor='#123' %}
-
-{% if metatags %}
-    {% for name, content in metatags %}
-        <meta name="{{ name }}" content="{{ content }}">
-    {% endfor %}
-{% endif %}
 
 {% if meta.styleSettingsCss %}
     <style>


### PR DESCRIPTION
# Changes

1. The [Open Graph Protocol](https://ogp.me/) suggests to use `property` as the key for meta tags instead of `name`, so all meta-tags starting with `og:` should go into `property`
2. I found a few StackOverflow [answers](https://stackoverflow.com/a/71124242) indicating that Facebook stops scraping `<head>` tag after a certain length. So just for safety, we should move the `metatags` to the start of the head.

