### PR TITLE
fix: add missing `:` (yaml typo)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,4 @@ updates:
       - dependency-name: "@sindresorhus/slugify"
         # For slugify, ignore all updates.
       - dependency-name: "@11ty/eleventy-plugin-rss"
-        versions [ "^1.2.0" ]
-      
-        
+        versions: [ "^1.2.0" ]


### PR DESCRIPTION
There's a yaml typo in the `dependabot.yml` file (missing `:` after `versions`)

Should be:
```yaml
versions: [ "^1.2.0" ]
```

Error that happened in my repo:

![image](https://github.com/user-attachments/assets/2d46cae1-cfce-4589-a044-1135a4a26007)
