### PR TITLE
feat: update lucide icons

### DIFF
--- a/src/site/_includes/components/calloutScript.njk
+++ b/src/site/_includes/components/calloutScript.njk
@@ -1,4 +1,4 @@
-<script async src="https://cdn.jsdelivr.net/npm/lucide@0.115.0/dist/umd/lucide.min.js"></script>
+<script async src="https://cdn.jsdelivr.net/npm/lucide@0.453.0/dist/umd/lucide.min.js"></script>
 <script>
     // Create callout icons
     window.addEventListener("load", () => {


### PR DESCRIPTION
Lucide icons here are terribly outdated. Since icons are backwards-compatible, there's no harm if we provide more icons than Obsidian does.