### PR TITLE
Resolve issues with mermaid diagram contrast in dark mode

### DIFF
--- a/src/site/styles/digital-garden-base.scss
+++ b/src/site/styles/digital-garden-base.scss
@@ -40,12 +40,6 @@ img {
     cursor: pointer;
 }
 
-.markdown-preview-view pre.mermaid {
-    background: white;
-    border-radius: 25px;
-    padding: 10px;
-}
-
 div.transclusion {
     position: relative;
     padding: 8px;


### PR DESCRIPTION
I mentioned this in #218, but there doesn't seem to be an issue for it.

Existing behavior seems to force a wolid white background, which seems to override the styling from my chosen Obsidian them. Removing this bit of code results in a readable mermaid diagram.