### PR TITLE
Load lucide library before calling it

### DIFF
--- a/src/site/_includes/components/lucideIcons.njk
+++ b/src/site/_includes/components/lucideIcons.njk
@@ -1,7 +1,8 @@
-<script>
-lucide.createIcons({
-            attrs: {
-                class: ["svg-icon"]
-            }
-        });
+<script defer src="https://unpkg.com/lucide@latest"></script>
+<script defer>
+  document.addEventListener('DOMContentLoaded', () => {
+    lucide.createIcons({
+      attrs: { class: ['svg-icon'] }
+    });
+  });
 </script>


### PR DESCRIPTION
**PR Summary**

**Purpose**
Load and initialize Lucide icons in a non-blocking way. This ensures all other scripts (theme toggler, sitemap, scrolling) run first, and then Lucide replaces `<i icon-name="…">` tags with SVG icons in every browser.

---

**Overview of Changes**

* **components/lucideIcons.njk**
  * Added `<script defer src="…lucide.min.js">` to load the Lucide UMD bundle without blocking page parsing.
  * Added a second `<script defer>` block that waits for **DOMContentLoaded**, then calls `lucide.createIcons()` to replace icon placeholders.

This change makes the icon loader run **after** all other page scripts, restoring normal functionality and fixing missing icons in Firefox.

---

**References**

* Lucide UMD usage: [https://lucide.dev/guide/packages/lucide](https://lucide.dev/guide/packages/lucide)
* `defer` attribute on `<script>`: [https://developer.mozilla.org/docs/Web/HTML/Element/script#defer](https://developer.mozilla.org/docs/Web/HTML/Element/script#defer)
* `DOMContentLoaded` event: [https://developer.mozilla.org/docs/Web/API/Window/DOMContentLoaded\_event](https://developer.mozilla.org/docs/Web/API/Window/DOMContentLoaded_event)
