### PR TITLE
chg: set position of sidebar overlay to 'fixed'

### DIFF
--- a/src/site/styles/digital-garden-base.scss
+++ b/src/site/styles/digital-garden-base.scss
@@ -424,7 +424,7 @@ ul.task-list {
 
 .fullpage-overlay {
     background-color: rgba(0, 0, 0, 0.5);
-    position: absolute;
+    position: fixed;
     top: 0;
     right: 0;
     left: 0;


### PR DESCRIPTION

## Summary

This pull request includes a small change to the `src/site/styles/digital-garden-base.scss` file. The change updates the `position` property of `.fullpage-overlay` from `absolute` to `fixed` to ensure the overlay remains fixed relative to the viewport.

---

## What is the issue

When the filetree is opened, the full page overlay is in an 'absolute' position, whereas the sidebar position is 'fixed'. This creates a disconnect when a visitor performs the following actions:
1. Open the filetree 
2. Scroll away from the top of the page
3. Try to close the filetree -> you can't

## Proposed solution

Consider changing the `position` property of the `.fullpage-overaly` from 'absolute' to 'fixed'. 

## Caveats

This disables the ability for the visitor to scroll through the page while the sidebar is opened. This seems like more reasonable behavior to me, but would like to discuss. 
