### PR TITLE
Random page

### DIFF
--- a/src/site/_includes/layouts/random.njk
+++ b/src/site/_includes/layouts/random.njk
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="{{ meta.mainLanguage }}">
+  <head>
+    <title>Random Page</title>
+    {% include "components/pageheader.njk" %}
+    <script>
+      // Get all published notes and redirect to a random one
+      const publishedNotes = [
+        {% for note in collections.note %}
+          {% if note.data['dg-publish'] %}
+            "{{ note.url }}",
+          {% endif %}
+        {% endfor %}
+      ];
+
+      if (publishedNotes.length > 0) {
+        const randomIndex = Math.floor(Math.random() * publishedNotes.length);
+        const randomUrl = publishedNotes[randomIndex];
+        window.location.href = randomUrl;
+      } else {
+
+        // Fallback to home if no notes found
+        window.location.href = '/';
+      }
+    </script>
+  </head>
+  
+  <body class="theme-{{meta.baseTheme}} markdown-preview-view markdown-rendered markdown-preview-section {{meta.bodyClasses}}">
+    <main class="content cm-s-obsidian">
+      <header>
+        <h1>Redirecting to Random Page...</h1>
+        <p>You are being redirected to a random page on the site!</p>
+      </header>
+      <div>
+        <p>If you are not redirected automatically, <a href="/">click here to go home</a>.</p>
+      </div>
+    </main>
+
+    <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.min.js"></script>
+    {% include "components/lucideIcons.njk" %}
+  </body>
+</html>

--- a/src/site/random.md
+++ b/src/site/random.md
@@ -1,0 +1,5 @@
+---
+layout: layouts/random.njk
+permalink: /random/
+eleventyExcludeFromCollections: true
+---

--- a/src/site/styles/digital-garden-base.scss
+++ b/src/site/styles/digital-garden-base.scss
@@ -424,7 +424,7 @@ ul.task-list {
 
 .fullpage-overlay {
     background-color: rgba(0, 0, 0, 0.5);
-    position: absolute;
+    position: fixed;
     top: 0;
     right: 0;
     left: 0;

--- a/src/site/styles/digital-garden-base.scss
+++ b/src/site/styles/digital-garden-base.scss
@@ -424,7 +424,7 @@ ul.task-list {
 
 .fullpage-overlay {
     background-color: rgba(0, 0, 0, 0.5);
-    position: fixed;
+    position: absolute;
     top: 0;
     right: 0;
     left: 0;


### PR DESCRIPTION
# Random navigation

For "serendipity" ~ randomly skipping through a garden is really fun. An easy way to do that is to route `/random` to re-direct the website to another valid page on the website (even hidden). 

## Notes

- The random selection respects the dg-publish frontmatter setting
- Includes proper error handling and fallback behavior
- Uses Eleventy's collections.note to dynamically generate the list of available notes
- Additional details posted here: https://www.paologabriel.com/swamp/random-navigation/
 - Also includes details on adding a "button"
 - Example of hidden interaction ~ I hid a picture of my cats on the same website above. can you find it?
- Could be a toggle in the plug-in, but that's beyond my skill set; also conflicts with a published page named "random"