### PR TITLE
Fix: Add case-insensitive URL matching for local graph lookup

### DIFF
--- a/src/site/_includes/components/graphScript.njk
+++ b/src/site/_includes/components/graphScript.njk
@@ -27,7 +27,16 @@
         let remaining = JSON.parse(JSON.stringify(graphData.nodes));
         let links = JSON.parse(JSON.stringify(graphData.links));
         let currentLink = decodeURI(window.location.pathname);
-        let currentNode = remaining[currentLink] || Object.values(remaining).find((v) => v.home);
+        // Try exact match first, then case-insensitive match for hosting platforms
+        // that normalize URLs to lowercase (e.g., Netlify)
+        let currentNode = remaining[currentLink];
+        if (!currentNode) {
+            const lowerCurrentLink = currentLink.toLowerCase();
+            currentNode = Object.values(remaining).find((v) => v.url.toLowerCase() === lowerCurrentLink);
+        }
+        if (!currentNode) {
+            currentNode = Object.values(remaining).find((v) => v.home);
+        }
         delete remaining[currentNode.url];
         if (!currentNode.home) {
             let home = Object.values(remaining).find((v) => v.home);


### PR DESCRIPTION
I asked Claude Code to figure out if it could fix the local graph not updating when changing notes on the webpage

Claude Code has explained the fix below, I tested and it works for me. I hope this is useful.

# Fix: Add case-insensitive URL matching for local graph lookup

## Summary
Fixes issue #247 where the local graph displays only the home node instead of the current page's connections when hosted on platforms that normalize URLs to lowercase (e.g., Netlify).

## Problem Description
When deploying to platforms like Netlify, URLs are automatically normalized to lowercase. However, the `graph.json` file contains URLs with their original casing (mixed case based on note titles). This creates a mismatch:

- **Browser URL**: `/notes/my-awesome-note` (lowercase)
- **graph.json key**: `/notes/My-Awesome-Note` (original casing)

The current implementation uses a direct key lookup in `graphScript.njk`:
```javascript
let currentNode = remaining[currentLink] || Object.values(remaining).find((v) => v.home);
```

When the exact case doesn't match, `remaining[currentLink]` returns `undefined`, and the code falls back to displaying the home node's graph instead of the current page.

## Solution
This PR implements a **two-stage lookup strategy** that maintains backward compatibility while fixing the case-sensitivity issue:

1. **Exact match** (preserves current behavior for platforms without URL normalization)
2. **Case-insensitive fallback** (handles platforms with URL normalization)
3. **Home node fallback** (existing safety net)

### Code Changes
```javascript
// Before
let currentNode = remaining[currentLink] || Object.values(remaining).find((v) => v.home);

// After
let currentNode = remaining[currentLink];
if (!currentNode) {
    const lowerCurrentLink = currentLink.toLowerCase();
    currentNode = Object.values(remaining).find((v) => v.url.toLowerCase() === lowerCurrentLink);
}
if (!currentNode) {
    currentNode = Object.values(remaining).find((v) => v.home);
}
```

## Testing
- ✅ Tested on Netlify deployment with mixed-case note titles
- ✅ Local graph now correctly displays current page connections
- ✅ Backward compatible: exact matches still work as before
- ✅ No breaking changes to existing functionality

## Related Issues
Closes #247

## Benefits
- **Fixes a common deployment issue** affecting users on Netlify and similar platforms
- **Zero breaking changes** - maintains exact match behavior when possible
- **Simple, focused solution** - minimal code changes with clear logic
- **Widely applicable** - helps users regardless of hosting platform

## Alternative Approaches Considered
The issue reporter suggested a `for...in` loop approach. This PR uses `Array.find()` which:
- Is more idiomatic modern JavaScript
- Provides better readability
- Maintains the existing code style in the file

---

**Live example**: https://gmnotesarendur.netlify.app/02%20player/erukana%20(nissen)/journal/kapitel%201%20-%20afslutning/ (any note page demonstrates the fix)
