### PR TITLE
feat: Add support for TikZJax diagrams.

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -7,7 +7,6 @@ const tocPlugin = require("eleventy-plugin-nesting-toc");
 const { parse } = require("node-html-parser");
 const htmlMinifier = require("html-minifier-terser");
 const pluginRss = require("@11ty/eleventy-plugin-rss");
-const tex2svg = require("node-tikzjax").default;
 
 const { headerToId, namedHeadingsFilter } = require("./src/helpers/utils");
 const {
@@ -507,32 +506,12 @@ module.exports = function (eleventyConfig) {
     return str && parsed.innerHTML;
   });
 
-  eleventyConfig.addTransform("htmlMinifier", async (content, outputPath) => {
-    if (
-      (process.env.NODE_ENV === "production" || process.env.ELEVENTY_ENV === "prod") &&
-      outputPath &&
-      outputPath.endsWith(".html")
-    ) {
-      try {
-        return await htmlMinifier.minify(content, {
-          useShortDoctype: true,
-          removeComments: true,
-          collapseWhitespace: true,
-          conservativeCollapse: true,
-          preserveLineBreaks: true,
-          minifyCSS: true,
-          minifyJS: true,
-          keepClosingSlash: true,
-        });
-      } catch {
-        // If the html minifying fails for some reason due to some malformed text, just return the content as is.
-        return content;
-      }
-    }
-    return content;
-  });
-
   eleventyConfig.addTransform("render-tikzjax", (() => {
+    // Lazy loading to save resources.
+    const tex2svg = require("node-tikzjax").default;
+
+    // Serialize renderings.
+    // Running node-tikzjax instances concurrently is problematic. See: https://github.com/prinsss/node-tikzjax/blob/main/README.md
     let tikzQueue = Promise.resolve();
 
     // https://github.com/artisticat1/obsidian-tikzjax/blob/main/main.ts
@@ -576,20 +555,56 @@ module.exports = function (eleventyConfig) {
           const svg = await run;
 
           const svgElement = parse(svg)
-            .querySelector("svg")                                   // after zooming some pictures could go wrong,
-            .setAttribute("style", "margin:auto; display:block;");  // e.g. oleeskild/obsidian-digital-garden#667
-          block.replaceWith(svgElement);
+            .querySelector("svg");
+          if (svgElement) {
+            // Zooming would result in other TikZ diagrams being overlapped or partly invisible.
+            svgElement.setAttribute("style", "margin:auto; display:block;");  // e.g. oleeskild/obsidian-digital-garden#667
+            block.replaceWith(svgElement);
+          }
         } catch (e) {
           console.warn("\n[TikZJax] render failed at:", outputPath);
           console.warn("[TikZJax] TeX source (first 400 chars):\n", texSource.slice(0, 400));
           console.warn("[TikZJax] Warn:", e);
-          block.replaceWith(`<pre><code class="language-tikz">TikZ render failed. See build log.\n\n${(texSource)}</code></pre>`);
+          // Escape texSource to be interpreted as HTML properly.
+          // https://stackoverflow.com/a/7382028
+          const texSource_escaped = texSource
+            .replaceAll("&", "&amp;")
+            .replaceAll("<", "&lt;")
+            .replaceAll(">", "&gt;")
+            .replaceAll('"', "&quot;")
+            .replaceAll("'", "&#39;");
+          block.replaceWith(`<pre><code class="language-tikz">TikZ render failed. See build log.\n\n${(texSource_escaped)}</code></pre>`);
         }
       }
 
       return root.toString();
     };
   })());
+
+  eleventyConfig.addTransform("htmlMinifier", async (content, outputPath) => {
+    if (
+      (process.env.NODE_ENV === "production" || process.env.ELEVENTY_ENV === "prod") &&
+      outputPath &&
+      outputPath.endsWith(".html")
+    ) {
+      try {
+        return await htmlMinifier.minify(content, {
+          useShortDoctype: true,
+          removeComments: true,
+          collapseWhitespace: true,
+          conservativeCollapse: true,
+          preserveLineBreaks: true,
+          minifyCSS: true,
+          minifyJS: true,
+          keepClosingSlash: true,
+        });
+      } catch {
+        // If the html minifying fails for some reason due to some malformed text, just return the content as is.
+        return content;
+      }
+    }
+    return content;
+  });
 
   eleventyConfig.addPassthroughCopy("src/site/img");
   eleventyConfig.addPassthroughCopy("src/site/scripts");

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
                 "markdown-it-mathjax3": "^4.3.1",
                 "markdown-it-plantuml": "^1.4.1",
                 "markdown-it-task-checkbox": "^1.0.6",
-                "node-tikzjax": "^1.0.3",
+                "node-tikzjax": "^1.0.5",
                 "npm-run-all": "^4.1.5",
                 "rimraf": "^4.4.1"
             },

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
         "markdown-it-mathjax3": "^4.3.1",
         "markdown-it-plantuml": "^1.4.1",
         "markdown-it-task-checkbox": "^1.0.6",
-        "node-tikzjax": "^1.0.3",
+        "node-tikzjax": "^1.0.5",
         "npm-run-all": "^4.1.5",
         "rimraf": "^4.4.1"
     }


### PR DESCRIPTION
As requested in
- oleeskild/obsidian-digital-garden#667
- oleeskild/obsidian-digital-garden#687

utilizing [prinsss/node-tikzjax](https://github.com/prinsss/node-tikzjax), now Digital Garden supports TikZJax diagrams:

<img width="1583" height="529" alt="image" src="https://github.com/user-attachments/assets/8b764f45-f447-48b5-bc33-a58e412a4db8" />

<img width="1409" height="755" alt="image" src="https://github.com/user-attachments/assets/d1b2ed99-397a-4539-8e81-cdcb9a7e938a" />


Check out https://mathematics-deployed.vercel.app/TikZJax/ for more examples, code of which can be found in https://github.com/LukeBriton/mathematics-deployed/blob/main/src/site/notes/TikZJax.md.

PS: Some commutative diagrams from the package `tikz-cd` are just that small, see the case of artisticat1/obsidian-tikzjax#42. I have tried to zoom them bigger, however that would result in other TikZ diagrams being overlapped or partly invisible.