### PR TITLE
Initial support for Folder Notes

### DIFF
--- a/src/helpers/filetreeUtils.js
+++ b/src/helpers/filetreeUtils.js
@@ -87,7 +87,7 @@ function getPermalinkMeta(note, key) {
     }
     if (note.data.tags && note.data.tags.indexOf("gardenEntry") != -1) {
       permalink = "/";
-    }    
+    }
     if (note.data.title) {
       name = note.data.title;
     }
@@ -133,12 +133,32 @@ function assignNested(obj, keyPath, value) {
   obj[keyPath[lastKeyIndex]] = value;
 }
 
+/**
+ * A folder note is a note with the same filename as the parent folder.
+ * Hide the folder note and link to it from the folder to treat it as a special case.
+ *
+ * @returns {void}
+ */
+function detectFoldersWithFolderNotes(parentName, parent) {
+  // Check if any of the children are notes with the same name
+  for (const [childName, child] of Object.entries(parent)) {
+    if (child.isNote && childName === (parentName + ".md")) {
+      // Found a folder note, hide the standalone link
+      child.hide = true;
+      parent.folderNote = child;
+    } else if (child.isFolder) {
+      detectFoldersWithFolderNotes(childName, child);
+    }
+  }
+}
+
 function getFileTree(data) {
   const tree = {};
   (data.collections.note || []).forEach((note) => {
     const [meta, folders] = getPermalinkMeta(note);
     assignNested(tree, folders, { isNote: true, ...meta });
   });
+  detectFoldersWithFolderNotes(null, tree);
   const fileTree = sortTree(tree);
   return fileTree;
 }

--- a/src/site/_includes/components/filetree.njk
+++ b/src/site/_includes/components/filetree.njk
@@ -3,14 +3,18 @@
         <div x-show="isOpen" style="display:none" class="{{'filelist' if step>0}}">
             {%if fileOrFolder.isNote and not fileOrFolder.hide %}
                 <div @click.stop class="notelink {{ 'active-note' if fileOrFolder.permalink === permalink}}">
-                    <a data-note-icon="{{fileOrFolder.noteIcon}}" style="text-decoration: none;" class="filename" href="{{fileOrFolder.permalink}}">{{fileOrFolder.name}} </a>
+                    <a data-note-icon="{{fileOrFolder.noteIcon}}" style="text-decoration: none;" class="filename" href="{{fileOrFolder.permalink}}">{{fileOrFolder.name}}</a>
                 </div>
             {% elif fileOrFolder.isFolder%}
                 <div class="folder inner-folder"  x-data="{isOpen: $persist(false).as({{currentPath | dump}})}" @click.stop="isOpen=!isOpen">
                     <div class="foldername-wrapper align-icon">
-                    <i x-show="isOpen" style="display: none;"  data-lucide="chevron-down"></i>
-                    <i x-show="!isOpen"  data-lucide="chevron-right"></i>
-                    <span class="foldername">{{fileOrFolderName}}</span>
+                        <i x-show="isOpen" style="display: none;" data-lucide="chevron-down"></i>
+                        <i x-show="!isOpen" data-lucide="chevron-right"></i>
+                        {% if fileOrFolder.folderNote %}
+                            <a @click.stop class="filename" href="{{fileOrFolder.folderNote.permalink}}">{{fileOrFolderName}}</a>
+                        {% else %}
+                            <span class="foldername">{{fileOrFolderName}}</span>
+                        {% endif %}
                     </div>
                     {% for fileOrFolderName, child in fileOrFolder %}
                         {{menuItem(fileOrFolderName, child, step+1, (currentPath+"/"+fileOrFolderName))}}
@@ -20,7 +24,7 @@
         </div>
         {%endif%}
     {% endmacro %}
-    
+
     <div x-init="isDesktop = (window.innerWidth>=1000) ? true: false;"
             x-on:resize.window="isDesktop = (window.innerWidth>=1000) ? true : false;"
             x-data="{isDesktop: true, showFilesMobile: false}">
@@ -28,7 +32,7 @@
         <div x-show.important="!isDesktop" style="display: none;">
             {%include "components/filetreeNavbar.njk"%}
         </div>
-        
+
         <div x-show="showFilesMobile && !isDesktop" @click="showFilesMobile = false" style="display:none;" class="fullpage-overlay"></div>
 
       <div class="filetree-wrapper" x-show.important="isDesktop || showFilesMobile" style="display: none;">


### PR DESCRIPTION
For folders with folder notes the click target to open the folder instead of navigating to the folder note is just the '>' icon, we should consider making it bigger.
Also, there's currently no "active-note" highlighting for folder notes, and the link doesn't have the typical underline on hover.
Even so it works pretty well overall, and I didn't notice any increase in build times.

Tested on my personal vault which uses [LostPaul/obsidian-folder-notes](https://github.com/LostPaul/obsidian-folder-notes)

Closes https://github.com/oleeskild/obsidian-digital-garden/issues/237
Closes https://github.com/oleeskild/obsidian-digital-garden/issues/669