### PR TITLE
Improve search normalization for accented Spanish words

### DIFF
--- a/src/site/_includes/components/searchScript.njk
+++ b/src/site/_includes/components/searchScript.njk
@@ -244,7 +244,19 @@
     // ===== FlexSearch Index =====
 
     function createIndex(posts) {
-        const encoder = (str) => str.toLowerCase().split(/([^a-z]|[^\x00-\x7F])/);
+        const normalizeForSearch = (str) => str
+            .toLowerCase()
+            // á -> a +  ́
+            .normalize("NFD")
+            // n~ -> ñ
+            .replace(/n\u0303/g, "ñ")
+            // áéíóúü -> aeiouu
+            .replace(/[\u0300-\u036f]/g, "")
+            // recompone Unicode
+            .normalize("NFC");
+
+        const encoder = (str) => normalizeForSearch(str)
+            .split(/([^a-z]|[^\x00-\x7F])/);
         const contentIndex = new FlexSearch.Document({
             cache: true,
             charset: "latin:extra",


### PR DESCRIPTION
## Summary

When users search words that contain accents in Spanish like _cápsulas_, now you get result even if you don't type it with accent.

- Normalize search tokens using Unicode decomposition.
- Remove accent/umlaut marks so queries without accents still match accented content.
- Preserve `ñ` as distinct from `n` for Spanish correctness.

<img width="791" height="241" alt="image" src="https://github.com/user-attachments/assets/89de10c0-ad21-491e-aff8-81abf873ea15" />


## Test plan
- Search `capsulas` and verify it matches pages containing `cápsulas`.
- Search `estres` and verify it matches `estrés`.
- Search `nino` and verify it does not collapse with `niño`.

## Scope note
This normalization is intentionally selective, not universal for every language.

- It removes combining acute accents (`\u0301`) and diaeresis/umlaut (`\u0308`), so queries without accents can match accented words in common Spanish cases.
- It intentionally preserves `ñ` as distinct from `n` for Spanish correctness.
- It does not strip all possible diacritics (e.g., grave, circumflex, cedilla, etc.).