### PR TITLE
feat: add Obsidian Bases support

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -13,6 +13,7 @@ const {
   userMarkdownSetup,
   userEleventySetup,
 } = require("./src/helpers/userSetup");
+const { basesPlugin } = require("./src/helpers/basesPlugin");
 
 const Image = require("@11ty/eleventy-img");
 function transformImage(src, cls, alt, sizes, widths = ["500", "700", "auto"]) {
@@ -140,6 +141,7 @@ module.exports = function(eleventyConfig) {
       closeMarker: "```",
     })
     .use(namedHeadingsFilter)
+    .use(basesPlugin)
     .use(function(md) {
       //https://github.com/DCsunset/markdown-it-mermaid-plugin
       const origFenceRule =

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
                 "fs-file-tree": "^1.1.1",
                 "glob": "^10.2.1",
                 "gray-matter": "^4.0.3",
+                "jsep": "^1.4.0",
                 "markdown-it": "^14.1.0",
                 "markdown-it-anchor": "^9.0.1",
                 "markdown-it-attrs": "^4.1.6",
@@ -27,7 +28,8 @@
                 "markdown-it-plantuml": "^1.4.1",
                 "markdown-it-task-checkbox": "^1.0.6",
                 "npm-run-all": "^4.1.5",
-                "rimraf": "^4.4.1"
+                "rimraf": "^4.4.1",
+                "yaml": "^2.8.3"
             },
             "devDependencies": {
                 "@11ty/eleventy": "^3.1.2",
@@ -35,7 +37,8 @@
                 "cross-env": "^10.1.0",
                 "html-minifier-terser": "^7.2.0",
                 "node-html-parser": "^7.0.2",
-                "sass": "^1.49.9"
+                "sass": "^1.49.9",
+                "vitest": "^4.1.0"
             },
             "engines": {
                 "node": "22.x"
@@ -373,10 +376,34 @@
                 "node": ">=18"
             }
         },
+        "node_modules/@emnapi/core": {
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.1.tgz",
+            "integrity": "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@emnapi/wasi-threads": "1.2.0",
+                "tslib": "^2.4.0"
+            }
+        },
         "node_modules/@emnapi/runtime": {
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.1.tgz",
+            "integrity": "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@emnapi/wasi-threads": {
             "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.2.0.tgz",
-            "integrity": "sha512-bV21/9LQmcQeCPEg3BDFtvwL6cwiTMksYNWQQ4KOxCZikEGalWtenoZ0wCiukJINlGCIi2KXx01g4FoH/LxpzQ==",
+            "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",
+            "integrity": "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==",
+            "dev": true,
+            "license": "MIT",
             "optional": true,
             "dependencies": {
                 "tslib": "^2.4.0"
@@ -879,10 +906,11 @@
             }
         },
         "node_modules/@jridgewell/sourcemap-codec": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
-            "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
-            "dev": true
+            "version": "1.5.5",
+            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+            "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@jridgewell/trace-mapping": {
             "version": "0.3.25",
@@ -894,6 +922,33 @@
                 "@jridgewell/sourcemap-codec": "^1.4.14"
             }
         },
+        "node_modules/@napi-rs/wasm-runtime": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.1.tgz",
+            "integrity": "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@emnapi/core": "^1.7.1",
+                "@emnapi/runtime": "^1.7.1",
+                "@tybys/wasm-util": "^0.10.1"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Brooooooklyn"
+            }
+        },
+        "node_modules/@oxc-project/types": {
+            "version": "0.120.0",
+            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.120.0.tgz",
+            "integrity": "sha512-k1YNu55DuvAip/MGE1FTsIuU3FUCn6v/ujG9V7Nq5Df/kX2CWb13hhwD0lmJGMGqE+bE1MXvv9SZVnMzEXlWcg==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/Boshen"
+            }
+        },
         "node_modules/@pkgjs/parseargs": {
             "version": "0.11.0",
             "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -902,6 +957,268 @@
             "engines": {
                 "node": ">=14"
             }
+        },
+        "node_modules/@rolldown/binding-android-arm64": {
+            "version": "1.0.0-rc.10",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.10.tgz",
+            "integrity": "sha512-jOHxwXhxmFKuXztiu1ORieJeTbx5vrTkcOkkkn2d35726+iwhrY1w/+nYY/AGgF12thg33qC3R1LMBF5tHTZHg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-darwin-arm64": {
+            "version": "1.0.0-rc.10",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.10.tgz",
+            "integrity": "sha512-gED05Teg/vtTZbIJBc4VNMAxAFDUPkuO/rAIyyxZjTj1a1/s6z5TII/5yMGZ0uLRCifEtwUQn8OlYzuYc0m70w==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-darwin-x64": {
+            "version": "1.0.0-rc.10",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.10.tgz",
+            "integrity": "sha512-rI15NcM1mA48lqrIxVkHfAqcyFLcQwyXWThy+BQ5+mkKKPvSO26ir+ZDp36AgYoYVkqvMcdS8zOE6SeBsR9e8A==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-freebsd-x64": {
+            "version": "1.0.0-rc.10",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.10.tgz",
+            "integrity": "sha512-XZRXHdTa+4ME1MuDVp021+doQ+z6Ei4CCFmNc5/sKbqb8YmkiJdj8QKlV3rCI0AJtAeSB5n0WGPuJWNL9p/L2w==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+            "version": "1.0.0-rc.10",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.10.tgz",
+            "integrity": "sha512-R0SQMRluISSLzFE20sPWYHVmJdDQnRyc/FzSCN72BqQmh2SOZUFG+N3/vBZpR4C6WpEUVYJLrYUXaj43sJsNLA==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-arm64-gnu": {
+            "version": "1.0.0-rc.10",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.10.tgz",
+            "integrity": "sha512-Y1reMrV/o+cwpduYhJuOE3OMKx32RMYCidf14y+HssARRmhDuWXJ4yVguDg2R/8SyyGNo+auzz64LnPK9Hq6jg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-arm64-musl": {
+            "version": "1.0.0-rc.10",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.10.tgz",
+            "integrity": "sha512-vELN+HNb2IzuzSBUOD4NHmP9yrGwl1DVM29wlQvx1OLSclL0NgVWnVDKl/8tEks79EFek/kebQKnNJkIAA4W2g==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+            "version": "1.0.0-rc.10",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.10.tgz",
+            "integrity": "sha512-ZqrufYTgzxbHwpqOjzSsb0UV/aV2TFIY5rP8HdsiPTv/CuAgCRjM6s9cYFwQ4CNH+hf9Y4erHW1GjZuZ7WoI7w==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-s390x-gnu": {
+            "version": "1.0.0-rc.10",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.10.tgz",
+            "integrity": "sha512-gSlmVS1FZJSRicA6IyjoRoKAFK7IIHBs7xJuHRSmjImqk3mPPWbR7RhbnfH2G6bcmMEllCt2vQ/7u9e6bBnByg==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-x64-gnu": {
+            "version": "1.0.0-rc.10",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.10.tgz",
+            "integrity": "sha512-eOCKUpluKgfObT2pHjztnaWEIbUabWzk3qPZ5PuacuPmr4+JtQG4k2vGTY0H15edaTnicgU428XW/IH6AimcQw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-x64-musl": {
+            "version": "1.0.0-rc.10",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.10.tgz",
+            "integrity": "sha512-Xdf2jQbfQowJnLcgYfD/m0Uu0Qj5OdxKallD78/IPPfzaiaI4KRAwZzHcKQ4ig1gtg1SuzC7jovNiM2TzQsBXA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-openharmony-arm64": {
+            "version": "1.0.0-rc.10",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.10.tgz",
+            "integrity": "sha512-o1hYe8hLi1EY6jgPFyxQgQ1wcycX+qz8eEbVmot2hFkgUzPxy9+kF0u0NIQBeDq+Mko47AkaFFaChcvZa9UX9Q==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openharmony"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-wasm32-wasi": {
+            "version": "1.0.0-rc.10",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.10.tgz",
+            "integrity": "sha512-Ugv9o7qYJudqQO5Y5y2N2SOo6S4WiqiNOpuQyoPInnhVzCY+wi/GHltcLHypG9DEUYMB0iTB/huJrpadiAcNcA==",
+            "cpu": [
+                "wasm32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@napi-rs/wasm-runtime": "^1.1.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@rolldown/binding-win32-arm64-msvc": {
+            "version": "1.0.0-rc.10",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.10.tgz",
+            "integrity": "sha512-7UODQb4fQUNT/vmgDZBl3XOBAIOutP5R3O/rkxg0aLfEGQ4opbCgU5vOw/scPe4xOqBwL9fw7/RP1vAMZ6QlAQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-win32-x64-msvc": {
+            "version": "1.0.0-rc.10",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.10.tgz",
+            "integrity": "sha512-PYxKHMVHOb5NJuDL53vBUl1VwUjymDcYI6rzpIni0C9+9mTiJedvUxSk7/RPp7OOAm3v+EjgMu9bIy3N6b408w==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/pluginutils": {
+            "version": "1.0.0-rc.10",
+            "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.10.tgz",
+            "integrity": "sha512-UkVDEFk1w3mveXeKgaTuYfKWtPbvgck1dT8TUG3bnccrH0XtLTuAyfCoks4Q/M5ZGToSVJTIQYCzy2g/atAOeg==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@sindresorhus/slugify": {
             "version": "1.1.2",
@@ -941,6 +1258,49 @@
                 "node": ">=8"
             }
         },
+        "node_modules/@standard-schema/spec": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+            "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@tybys/wasm-util": {
+            "version": "0.10.1",
+            "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+            "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@types/chai": {
+            "version": "5.2.3",
+            "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+            "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/deep-eql": "*",
+                "assertion-error": "^2.0.1"
+            }
+        },
+        "node_modules/@types/deep-eql": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+            "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/estree": {
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+            "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@types/linkify-it": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
@@ -963,10 +1323,118 @@
             "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
             "peer": true
         },
-        "node_modules/@types/node": {
-            "version": "17.0.45",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
-            "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw=="
+        "node_modules/@vitest/expect": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.0.tgz",
+            "integrity": "sha512-EIxG7k4wlWweuCLG9Y5InKFwpMEOyrMb6ZJ1ihYu02LVj/bzUwn2VMU+13PinsjRW75XnITeFrQBMH5+dLvCDA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@standard-schema/spec": "^1.1.0",
+                "@types/chai": "^5.2.2",
+                "@vitest/spy": "4.1.0",
+                "@vitest/utils": "4.1.0",
+                "chai": "^6.2.2",
+                "tinyrainbow": "^3.0.3"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/mocker": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.0.tgz",
+            "integrity": "sha512-evxREh+Hork43+Y4IOhTo+h5lGmVRyjqI739Rz4RlUPqwrkFFDF6EMvOOYjTx4E8Tl6gyCLRL8Mu7Ry12a13Tw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/spy": "4.1.0",
+                "estree-walker": "^3.0.3",
+                "magic-string": "^0.30.21"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "msw": "^2.4.9",
+                "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0"
+            },
+            "peerDependenciesMeta": {
+                "msw": {
+                    "optional": true
+                },
+                "vite": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@vitest/pretty-format": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.0.tgz",
+            "integrity": "sha512-3RZLZlh88Ib0J7NQTRATfc/3ZPOnSUn2uDBUoGNn5T36+bALixmzphN26OUD3LRXWkJu4H0s5vvUeqBiw+kS0A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tinyrainbow": "^3.0.3"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/runner": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.0.tgz",
+            "integrity": "sha512-Duvx2OzQ7d6OjchL+trw+aSrb9idh7pnNfxrklo14p3zmNL4qPCDeIJAK+eBKYjkIwG96Bc6vYuxhqDXQOWpoQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/utils": "4.1.0",
+                "pathe": "^2.0.3"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/snapshot": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.0.tgz",
+            "integrity": "sha512-0Vy9euT1kgsnj1CHttwi9i9o+4rRLEaPRSOJ5gyv579GJkNpgJK+B4HSv/rAWixx2wdAFci1X4CEPjiu2bXIMg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/pretty-format": "4.1.0",
+                "@vitest/utils": "4.1.0",
+                "magic-string": "^0.30.21",
+                "pathe": "^2.0.3"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/spy": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.0.tgz",
+            "integrity": "sha512-pz77k+PgNpyMDv2FV6qmk5ZVau6c3R8HC8v342T2xlFxQKTrSeYw9waIJG8KgV9fFwAtTu4ceRzMivPTH6wSxw==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/utils": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.0.tgz",
+            "integrity": "sha512-XfPXT6a8TZY3dcGY8EdwsBulFCIw+BeeX0RZn2x/BtiY/75YGh8FeWGG8QISN/WhaqSrE2OrlDgtF8q5uhOTmw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/pretty-format": "4.1.0",
+                "convert-source-map": "^2.0.0",
+                "tinyrainbow": "^3.0.3"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
         },
         "node_modules/a-sync-waterfall": {
             "version": "1.0.1",
@@ -1138,6 +1606,16 @@
             "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
             "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
             "dev": true
+        },
+        "node_modules/assertion-error": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+            "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            }
         },
         "node_modules/assured": {
             "version": "1.0.15",
@@ -1330,6 +1808,16 @@
                 "uc-first-array": "^1.1.10"
             }
         },
+        "node_modules/chai": {
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+            "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/cheerio": {
             "version": "1.0.0-rc.12",
             "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.12.tgz",
@@ -1449,6 +1937,13 @@
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
             "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+        },
+        "node_modules/convert-source-map": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+            "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/cross-env": {
             "version": "10.1.0",
@@ -1913,6 +2408,13 @@
                 "node": ">= 0.4"
             }
         },
+        "node_modules/es-module-lexer": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+            "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/es-object-atoms": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -2015,6 +2517,16 @@
                 "node": ">=4"
             }
         },
+        "node_modules/estree-walker": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+            "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/estree": "^1.0.0"
+            }
+        },
         "node_modules/etag": {
             "version": "1.8.1",
             "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
@@ -2039,6 +2551,16 @@
             "version": "4.0.7",
             "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
             "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
+        },
+        "node_modules/expect-type": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+            "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=12.0.0"
+            }
         },
         "node_modules/extend-shallow": {
             "version": "2.0.1",
@@ -3058,6 +3580,15 @@
                 "js-yaml": "bin/js-yaml.js"
             }
         },
+        "node_modules/jsep": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
+            "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 10.16.0"
+            }
+        },
         "node_modules/json-buffer": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
@@ -3258,6 +3789,267 @@
                 "node": ">=6"
             }
         },
+        "node_modules/lightningcss": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+            "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+            "dev": true,
+            "license": "MPL-2.0",
+            "dependencies": {
+                "detect-libc": "^2.0.3"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            },
+            "optionalDependencies": {
+                "lightningcss-android-arm64": "1.32.0",
+                "lightningcss-darwin-arm64": "1.32.0",
+                "lightningcss-darwin-x64": "1.32.0",
+                "lightningcss-freebsd-x64": "1.32.0",
+                "lightningcss-linux-arm-gnueabihf": "1.32.0",
+                "lightningcss-linux-arm64-gnu": "1.32.0",
+                "lightningcss-linux-arm64-musl": "1.32.0",
+                "lightningcss-linux-x64-gnu": "1.32.0",
+                "lightningcss-linux-x64-musl": "1.32.0",
+                "lightningcss-win32-arm64-msvc": "1.32.0",
+                "lightningcss-win32-x64-msvc": "1.32.0"
+            }
+        },
+        "node_modules/lightningcss-android-arm64": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+            "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-darwin-arm64": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+            "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-darwin-x64": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+            "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-freebsd-x64": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+            "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-arm-gnueabihf": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+            "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-arm64-gnu": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+            "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-arm64-musl": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+            "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-x64-gnu": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+            "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-x64-musl": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+            "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-win32-arm64-msvc": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+            "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-win32-x64-msvc": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+            "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
         "node_modules/linkify-it": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
@@ -3339,6 +4131,16 @@
             "license": "MIT",
             "engines": {
                 "node": ">=12"
+            }
+        },
+        "node_modules/magic-string": {
+            "version": "0.30.21",
+            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+            "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/sourcemap-codec": "^1.5.5"
             }
         },
         "node_modules/markdown-it": {
@@ -3583,6 +4385,25 @@
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
             "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
             "license": "MIT"
+        },
+        "node_modules/nanoid": {
+            "version": "3.3.11",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+            "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "license": "MIT",
+            "bin": {
+                "nanoid": "bin/nanoid.cjs"
+            },
+            "engines": {
+                "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+            }
         },
         "node_modules/nice-try": {
             "version": "1.0.5",
@@ -3916,6 +4737,17 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/obug": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+            "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+            "dev": true,
+            "funding": [
+                "https://github.com/sponsors/sxzz",
+                "https://opencollective.com/debug"
+            ],
+            "license": "MIT"
+        },
         "node_modules/on-finished": {
             "version": "2.4.1",
             "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -4104,6 +4936,20 @@
                 "node": ">=4"
             }
         },
+        "node_modules/pathe": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+            "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/picocolors": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+            "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+            "dev": true,
+            "license": "ISC"
+        },
         "node_modules/picomatch": {
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
@@ -4161,6 +5007,12 @@
                 "node": ">=8"
             }
         },
+        "node_modules/png-to-ico/node_modules/@types/node": {
+            "version": "17.0.45",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
+            "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==",
+            "license": "MIT"
+        },
         "node_modules/pngjs": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-6.0.0.tgz",
@@ -4175,6 +5027,35 @@
             "integrity": "sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==",
             "engines": {
                 "node": ">= 0.4"
+            }
+        },
+        "node_modules/postcss": {
+            "version": "8.5.8",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+            "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/postcss/"
+                },
+                {
+                    "type": "tidelift",
+                    "url": "https://tidelift.com/funding/github/npm/postcss"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "nanoid": "^3.3.11",
+                "picocolors": "^1.1.1",
+                "source-map-js": "^1.2.1"
+            },
+            "engines": {
+                "node": "^10 || ^12 || >=14"
             }
         },
         "node_modules/posthtml": {
@@ -4489,6 +5370,40 @@
                 "node": ">=8"
             }
         },
+        "node_modules/rolldown": {
+            "version": "1.0.0-rc.10",
+            "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.10.tgz",
+            "integrity": "sha512-q7j6vvarRFmKpgJUT8HCAUljkgzEp4LAhPlJUvQhA5LA1SUL36s5QCysMutErzL3EbNOZOkoziSx9iZC4FddKA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@oxc-project/types": "=0.120.0",
+                "@rolldown/pluginutils": "1.0.0-rc.10"
+            },
+            "bin": {
+                "rolldown": "bin/cli.mjs"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            },
+            "optionalDependencies": {
+                "@rolldown/binding-android-arm64": "1.0.0-rc.10",
+                "@rolldown/binding-darwin-arm64": "1.0.0-rc.10",
+                "@rolldown/binding-darwin-x64": "1.0.0-rc.10",
+                "@rolldown/binding-freebsd-x64": "1.0.0-rc.10",
+                "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.10",
+                "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.10",
+                "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.10",
+                "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.10",
+                "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.10",
+                "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.10",
+                "@rolldown/binding-linux-x64-musl": "1.0.0-rc.10",
+                "@rolldown/binding-openharmony-arm64": "1.0.0-rc.10",
+                "@rolldown/binding-wasm32-wasi": "1.0.0-rc.10",
+                "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.10",
+                "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.10"
+            }
+        },
         "node_modules/safe-array-concat": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.2.tgz",
@@ -4752,6 +5667,13 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/siginfo": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+            "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+            "dev": true,
+            "license": "ISC"
+        },
         "node_modules/signal-exit": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -4818,10 +5740,11 @@
             }
         },
         "node_modules/source-map-js": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
-            "integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+            "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
             "dev": true,
+            "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -4903,6 +5826,13 @@
                 "node": "^16.14.0 || >=18.0.0"
             }
         },
+        "node_modules/stackback": {
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+            "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/statuses": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
@@ -4912,6 +5842,13 @@
             "engines": {
                 "node": ">= 0.8"
             }
+        },
+        "node_modules/std-env": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
+            "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/string-width": {
             "version": "5.1.2",
@@ -5109,6 +6046,23 @@
                 "node": ">=10"
             }
         },
+        "node_modules/tinybench": {
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+            "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/tinyexec": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.4.tgz",
+            "integrity": "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/tinyglobby": {
             "version": "0.2.15",
             "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -5155,6 +6109,16 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "node_modules/tinyrainbow": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+            "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.0.0"
             }
         },
         "node_modules/to-regex-range": {
@@ -5330,6 +6294,192 @@
             "dependencies": {
                 "spdx-correct": "^3.0.0",
                 "spdx-expression-parse": "^3.0.0"
+            }
+        },
+        "node_modules/vite": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.1.tgz",
+            "integrity": "sha512-wt+Z2qIhfFt85uiyRt5LPU4oVEJBXj8hZNWKeqFG4gRG/0RaRGJ7njQCwzFVjO+v4+Ipmf5CY7VdmZRAYYBPHw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "lightningcss": "^1.32.0",
+                "picomatch": "^4.0.3",
+                "postcss": "^8.5.8",
+                "rolldown": "1.0.0-rc.10",
+                "tinyglobby": "^0.2.15"
+            },
+            "bin": {
+                "vite": "bin/vite.js"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            },
+            "funding": {
+                "url": "https://github.com/vitejs/vite?sponsor=1"
+            },
+            "optionalDependencies": {
+                "fsevents": "~2.3.3"
+            },
+            "peerDependencies": {
+                "@types/node": "^20.19.0 || >=22.12.0",
+                "@vitejs/devtools": "^0.1.0",
+                "esbuild": "^0.27.0",
+                "jiti": ">=1.21.0",
+                "less": "^4.0.0",
+                "sass": "^1.70.0",
+                "sass-embedded": "^1.70.0",
+                "stylus": ">=0.54.8",
+                "sugarss": "^5.0.0",
+                "terser": "^5.16.0",
+                "tsx": "^4.8.1",
+                "yaml": "^2.4.2"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                },
+                "@vitejs/devtools": {
+                    "optional": true
+                },
+                "esbuild": {
+                    "optional": true
+                },
+                "jiti": {
+                    "optional": true
+                },
+                "less": {
+                    "optional": true
+                },
+                "sass": {
+                    "optional": true
+                },
+                "sass-embedded": {
+                    "optional": true
+                },
+                "stylus": {
+                    "optional": true
+                },
+                "sugarss": {
+                    "optional": true
+                },
+                "terser": {
+                    "optional": true
+                },
+                "tsx": {
+                    "optional": true
+                },
+                "yaml": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/vite/node_modules/picomatch": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+            "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "node_modules/vitest": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.0.tgz",
+            "integrity": "sha512-YbDrMF9jM2Lqc++2530UourxZHmkKLxrs4+mYhEwqWS97WJ7wOYEkcr+QfRgJ3PW9wz3odRijLZjHEaRLTNbqw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/expect": "4.1.0",
+                "@vitest/mocker": "4.1.0",
+                "@vitest/pretty-format": "4.1.0",
+                "@vitest/runner": "4.1.0",
+                "@vitest/snapshot": "4.1.0",
+                "@vitest/spy": "4.1.0",
+                "@vitest/utils": "4.1.0",
+                "es-module-lexer": "^2.0.0",
+                "expect-type": "^1.3.0",
+                "magic-string": "^0.30.21",
+                "obug": "^2.1.1",
+                "pathe": "^2.0.3",
+                "picomatch": "^4.0.3",
+                "std-env": "^4.0.0-rc.1",
+                "tinybench": "^2.9.0",
+                "tinyexec": "^1.0.2",
+                "tinyglobby": "^0.2.15",
+                "tinyrainbow": "^3.0.3",
+                "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0",
+                "why-is-node-running": "^2.3.0"
+            },
+            "bin": {
+                "vitest": "vitest.mjs"
+            },
+            "engines": {
+                "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "@edge-runtime/vm": "*",
+                "@opentelemetry/api": "^1.9.0",
+                "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+                "@vitest/browser-playwright": "4.1.0",
+                "@vitest/browser-preview": "4.1.0",
+                "@vitest/browser-webdriverio": "4.1.0",
+                "@vitest/ui": "4.1.0",
+                "happy-dom": "*",
+                "jsdom": "*",
+                "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0"
+            },
+            "peerDependenciesMeta": {
+                "@edge-runtime/vm": {
+                    "optional": true
+                },
+                "@opentelemetry/api": {
+                    "optional": true
+                },
+                "@types/node": {
+                    "optional": true
+                },
+                "@vitest/browser-playwright": {
+                    "optional": true
+                },
+                "@vitest/browser-preview": {
+                    "optional": true
+                },
+                "@vitest/browser-webdriverio": {
+                    "optional": true
+                },
+                "@vitest/ui": {
+                    "optional": true
+                },
+                "happy-dom": {
+                    "optional": true
+                },
+                "jsdom": {
+                    "optional": true
+                },
+                "vite": {
+                    "optional": false
+                }
+            }
+        },
+        "node_modules/vitest/node_modules/picomatch": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+            "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
             }
         },
         "node_modules/web-resource-inliner": {
@@ -5510,6 +6660,23 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/why-is-node-running": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+            "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "siginfo": "^2.0.0",
+                "stackback": "0.0.2"
+            },
+            "bin": {
+                "why-is-node-running": "cli.js"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/wicked-good-xpath": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/wicked-good-xpath/-/wicked-good-xpath-1.3.0.tgz",
@@ -5629,6 +6796,21 @@
             "integrity": "sha512-f9s+fUkX04BxQf+7mMWAp5zk61pciie+fFLC9hX9UVvCeJQfNHRHXpeo5MPcR0EUf57PYLdt+ZO4f3Ipk2oZUw==",
             "engines": {
                 "node": ">=0.1"
+            }
+        },
+        "node_modules/yaml": {
+            "version": "2.8.3",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+            "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+            "license": "ISC",
+            "bin": {
+                "yaml": "bin.mjs"
+            },
+            "engines": {
+                "node": ">= 14.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/eemeli"
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -11,13 +11,14 @@
         "build:eleventy": "cross-env ELEVENTY_ENV=prod NODE_OPTIONS=--max-old-space-size=4096 eleventy",
         "build:sass": "sass src/site/styles:dist/styles --style compressed",
         "get-theme": "node src/site/get-theme.js",
-        "build": "npm-run-all get-theme build:*"
+        "build": "npm-run-all get-theme build:*",
+        "test": "vitest run"
     },
     "keywords": [],
     "author": "",
     "license": "ISC",
     "engines": {
-      "node": "22.x"
+        "node": "22.x"
     },
     "devDependencies": {
         "@11ty/eleventy": "^3.1.2",
@@ -25,7 +26,8 @@
         "cross-env": "^10.1.0",
         "html-minifier-terser": "^7.2.0",
         "node-html-parser": "^7.0.2",
-        "sass": "^1.49.9"
+        "sass": "^1.49.9",
+        "vitest": "^4.1.0"
     },
     "dependencies": {
         "@11ty/eleventy-img": "^4.0.2",
@@ -37,6 +39,7 @@
         "fs-file-tree": "^1.1.1",
         "glob": "^10.2.1",
         "gray-matter": "^4.0.3",
+        "jsep": "^1.4.0",
         "markdown-it": "^14.1.0",
         "markdown-it-anchor": "^9.0.1",
         "markdown-it-attrs": "^4.1.6",
@@ -46,6 +49,7 @@
         "markdown-it-plantuml": "^1.4.1",
         "markdown-it-task-checkbox": "^1.0.6",
         "npm-run-all": "^4.1.5",
-        "rimraf": "^4.4.1"
+        "rimraf": "^4.4.1",
+        "yaml": "^2.8.3"
     }
 }

--- a/plugin-info.json
+++ b/plugin-info.json
@@ -26,7 +26,15 @@
         "vercel.json",
         "netlify.toml",
         "src/site/_includes/layouts/random.njk",
-        "src/site/random.md"
+        "src/site/random.md",
+        "src/helpers/bases-engine/index.js",
+        "src/helpers/bases-engine/exprParser.js",
+        "src/helpers/bases-engine/exprEval.js",
+        "src/helpers/bases-engine/queryEngine.js",
+        "src/helpers/bases-engine/views.js",
+        "src/helpers/basesPlugin.js",
+        "src/site/_includes/components/basesScript.njk",
+        "src/site/styles/obsidian-bases.scss"
     ],
     "filesToModify": [
         ".eleventy.js",

--- a/src/helpers/bases-engine/__tests__/exprEval.test.js
+++ b/src/helpers/bases-engine/__tests__/exprEval.test.js
@@ -1,0 +1,785 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { evalExpr, evalFilter } from "../exprEval.js";
+import { parseExpression } from "../exprParser.js";
+
+// Helper to evaluate expression string against a note
+function evaluate(expr, note, formulas = {}, context = {}) {
+	const ast = parseExpression(expr);
+	return evalExpr(ast, note, formulas, context);
+}
+
+const sampleNote = {
+	path: "books/The Great Gatsby.md",
+	url: "/notes/the-great-gatsby/",
+	metadata: {
+		tags: ["note", "fiction", "classic"],
+		author: "Fitzgerald",
+		year: 1925,
+		rating: 4.5,
+		status: "read",
+		links: ["other-note", "another-note"],
+	},
+	fileSlug: "the-great-gatsby",
+	__formulas: { readingTime: 5 },
+};
+
+describe("exprEval", () => {
+	describe("property resolution", () => {
+		it("resolves simple identifier from metadata", () => {
+			expect(evaluate("author", sampleNote)).toBe("Fitzgerald");
+		});
+
+		it("resolves note.property from metadata", () => {
+			expect(evaluate("note.author", sampleNote)).toBe("Fitzgerald");
+		});
+
+		it('resolves note["property"] from metadata', () => {
+			expect(evaluate('note["author"]', sampleNote)).toBe("Fitzgerald");
+		});
+
+		it("resolves file.name to filename without extension", () => {
+			expect(evaluate("file.name", sampleNote)).toBe("The Great Gatsby");
+		});
+
+		it("resolves file.path", () => {
+			expect(evaluate("file.path", sampleNote)).toBe(
+				"books/The Great Gatsby.md",
+			);
+		});
+
+		it("resolves file.folder", () => {
+			expect(evaluate("file.folder", sampleNote)).toBe("books");
+		});
+
+		it("resolves file.ext", () => {
+			expect(evaluate("file.ext", sampleNote)).toBe("md");
+		});
+
+		it("resolves file.tags (system tags filtered out)", () => {
+			expect(evaluate("file.tags", sampleNote)).toEqual([
+				"fiction",
+				"classic",
+			]);
+		});
+
+		it("resolves formula.X from __formulas", () => {
+			expect(evaluate("formula.readingTime", sampleNote)).toBe(5);
+		});
+
+		it("resolves formula.X from formulas parameter", () => {
+			expect(evaluate("formula.custom", sampleNote, { custom: 42 })).toBe(42);
+		});
+
+		it("returns undefined for missing metadata property", () => {
+			expect(evaluate("nonexistent", sampleNote)).toBeUndefined();
+		});
+
+		it("resolves file.size from metadata", () => {
+			const note = {
+				...sampleNote,
+				metadata: { ...sampleNote.metadata, size: 1024 },
+			};
+			expect(evaluate("file.size", note)).toBe(1024);
+		});
+
+		it("resolves file.ctime and file.mtime from metadata", () => {
+			const note = {
+				...sampleNote,
+				metadata: {
+					...sampleNote.metadata,
+					ctime: "2024-01-01",
+					mtime: "2024-06-01",
+				},
+			};
+			expect(evaluate("file.ctime", note)).toBe("2024-01-01");
+			expect(evaluate("file.mtime", note)).toBe("2024-06-01");
+		});
+	});
+
+	describe("literals", () => {
+		it("evaluates string literal", () => {
+			expect(evaluate('"hello"', sampleNote)).toBe("hello");
+		});
+
+		it("evaluates numeric literal", () => {
+			expect(evaluate("42", sampleNote)).toBe(42);
+		});
+
+		it("evaluates boolean-like via identifier", () => {
+			expect(evaluate("true", sampleNote)).toBe(true);
+			expect(evaluate("false", sampleNote)).toBe(false);
+		});
+	});
+
+	describe("comparison operators", () => {
+		it("evaluates == with loose equality", () => {
+			expect(evaluate('author == "Fitzgerald"', sampleNote)).toBe(true);
+			expect(evaluate('author == "Other"', sampleNote)).toBe(false);
+		});
+
+		it("evaluates !=", () => {
+			expect(evaluate('author != "Other"', sampleNote)).toBe(true);
+			expect(evaluate('author != "Fitzgerald"', sampleNote)).toBe(false);
+		});
+
+		it("evaluates >", () => {
+			expect(evaluate("year > 1900", sampleNote)).toBe(true);
+			expect(evaluate("year > 2000", sampleNote)).toBe(false);
+		});
+
+		it("evaluates <", () => {
+			expect(evaluate("year < 2000", sampleNote)).toBe(true);
+			expect(evaluate("year < 1900", sampleNote)).toBe(false);
+		});
+
+		it("evaluates >=", () => {
+			expect(evaluate("year >= 1925", sampleNote)).toBe(true);
+			expect(evaluate("year >= 1926", sampleNote)).toBe(false);
+		});
+
+		it("evaluates <=", () => {
+			expect(evaluate("year <= 1925", sampleNote)).toBe(true);
+			expect(evaluate("year <= 1924", sampleNote)).toBe(false);
+		});
+	});
+
+	describe("arithmetic operators", () => {
+		it("evaluates addition", () => {
+			expect(evaluate("year + 1", sampleNote)).toBe(1926);
+		});
+
+		it("evaluates subtraction", () => {
+			expect(evaluate("year - 25", sampleNote)).toBe(1900);
+		});
+
+		it("evaluates multiplication", () => {
+			expect(evaluate("rating * 2", sampleNote)).toBe(9);
+		});
+
+		it("evaluates division", () => {
+			expect(evaluate("rating / 2", sampleNote)).toBe(2.25);
+		});
+
+		it("evaluates modulo", () => {
+			expect(evaluate("year % 100", sampleNote)).toBe(25);
+		});
+
+		it("division by zero returns undefined", () => {
+			expect(evaluate("5 / 0", sampleNote)).toBeUndefined();
+		});
+	});
+
+	describe("boolean logic", () => {
+		it("evaluates && (both true)", () => {
+			expect(
+				evaluate('author == "Fitzgerald" && year == 1925', sampleNote),
+			).toBe(true);
+		});
+
+		it("evaluates && (one false)", () => {
+			expect(evaluate('author == "Fitzgerald" && year > 2000', sampleNote)).toBe(
+				false,
+			);
+		});
+
+		it("evaluates || (one true)", () => {
+			expect(evaluate('author == "Other" || year == 1925', sampleNote)).toBe(
+				true,
+			);
+		});
+
+		it("evaluates || (both false)", () => {
+			expect(evaluate('author == "Other" || year > 2000', sampleNote)).toBe(
+				false,
+			);
+		});
+
+		it("evaluates unary !", () => {
+			expect(evaluate('!(author == "Other")', sampleNote)).toBe(true);
+			expect(evaluate('!(author == "Fitzgerald")', sampleNote)).toBe(false);
+		});
+
+		it("evaluates unary -", () => {
+			expect(evaluate("-year", sampleNote)).toBe(-1925);
+		});
+	});
+
+	describe("filter functions", () => {
+		it('file.hasTag("fiction") returns true', () => {
+			expect(evaluate('file.hasTag("fiction")', sampleNote)).toBe(true);
+		});
+
+		it('file.hasTag("nonexistent") returns false', () => {
+			expect(evaluate('file.hasTag("nonexistent")', sampleNote)).toBe(false);
+		});
+
+		it("file.hasTag with # prefix", () => {
+			expect(evaluate('file.hasTag("#fiction")', sampleNote)).toBe(true);
+		});
+
+		it('file.inFolder("books") returns true', () => {
+			expect(evaluate('file.inFolder("books")', sampleNote)).toBe(true);
+		});
+
+		it('file.inFolder("other") returns false', () => {
+			expect(evaluate('file.inFolder("other")', sampleNote)).toBe(false);
+		});
+
+		it('file.inFolder("books/") with trailing slash still matches', () => {
+			expect(evaluate('file.inFolder("books/")', sampleNote)).toBe(true);
+		});
+
+		it('file.hasProperty("author") returns true', () => {
+			expect(evaluate('file.hasProperty("author")', sampleNote)).toBe(true);
+		});
+
+		it('file.hasProperty("nonexistent") returns false', () => {
+			expect(evaluate('file.hasProperty("nonexistent")', sampleNote)).toBe(
+				false,
+			);
+		});
+
+		it('file.hasLink("other-note") returns true', () => {
+			expect(evaluate('file.hasLink("other-note")', sampleNote)).toBe(true);
+		});
+
+		it('file.hasLink("missing") returns false', () => {
+			expect(evaluate('file.hasLink("missing")', sampleNote)).toBe(false);
+		});
+	});
+
+	describe("global functions", () => {
+		it("today() returns a Date object", () => {
+			const result = evaluate("today()", sampleNote);
+			expect(result instanceof Date).toBe(true);
+		});
+
+		it("today() returns midnight (time zeroed)", () => {
+			const result = evaluate("today()", sampleNote);
+			expect(result.getHours()).toBe(0);
+			expect(result.getMinutes()).toBe(0);
+			expect(result.getSeconds()).toBe(0);
+			expect(result.getMilliseconds()).toBe(0);
+		});
+
+		it("today() supports .year chaining", () => {
+			const result = evaluate("today().year", sampleNote);
+			expect(typeof result).toBe("number");
+			expect(result).toBeGreaterThan(2000);
+		});
+
+		it("today() supports .month chaining", () => {
+			const result = evaluate("today().month", sampleNote);
+			expect(typeof result).toBe("number");
+			expect(result).toBeGreaterThanOrEqual(1);
+			expect(result).toBeLessThanOrEqual(12);
+		});
+
+		it("today() supports .day chaining", () => {
+			const result = evaluate("today().day", sampleNote);
+			expect(typeof result).toBe("number");
+			expect(result).toBeGreaterThanOrEqual(1);
+			expect(result).toBeLessThanOrEqual(31);
+		});
+
+		it("today() supports .format() chaining", () => {
+			const result = evaluate('today().format("YYYY-MM-DD")', sampleNote);
+			expect(result).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+		});
+
+		it("now() returns a Date object", () => {
+			const result = evaluate("now()", sampleNote);
+			expect(result instanceof Date).toBe(true);
+		});
+
+		it("now() returns current time (within 5 seconds)", () => {
+			const before = Date.now();
+			const result = evaluate("now()", sampleNote);
+			const after = Date.now();
+			expect(result.getTime()).toBeGreaterThanOrEqual(before);
+			expect(result.getTime()).toBeLessThanOrEqual(after);
+		});
+
+		it("if(condition, trueVal, falseVal) returns correct branch", () => {
+			expect(evaluate('if(year > 1900, "yes", "no")', sampleNote)).toBe("yes");
+			expect(evaluate('if(year > 2000, "yes", "no")', sampleNote)).toBe("no");
+		});
+
+		it("number() converts to number", () => {
+			expect(evaluate('number("42")', sampleNote)).toBe(42);
+		});
+
+		it("min() returns minimum", () => {
+			expect(evaluate("min(3, 1, 2)", sampleNote)).toBe(1);
+		});
+
+		it("max() returns maximum", () => {
+			expect(evaluate("max(3, 1, 2)", sampleNote)).toBe(3);
+		});
+
+		it("list() wraps value in array", () => {
+			expect(evaluate('list("hello")', sampleNote)).toEqual(["hello"]);
+		});
+
+		it("list() returns array as-is", () => {
+			expect(evaluate("list(file.tags)", sampleNote)).toEqual([
+				"fiction",
+				"classic",
+			]);
+		});
+
+		it("list() with multiple args returns all args", () => {
+			expect(evaluate("list(1, 2, 3)", sampleNote)).toEqual([1, 2, 3]);
+		});
+
+		it("date() returns Date object", () => {
+			const result = evaluate('date("2024-01-15")', sampleNote);
+			expect(result instanceof Date).toBe(true);
+			expect(result.getFullYear()).toBe(2024);
+		});
+
+		it("date(undefined) returns undefined", () => {
+			expect(evaluate("date(undefined)", sampleNote)).toBeUndefined();
+		});
+
+		it('date("not-a-date") returns undefined', () => {
+			expect(evaluate('date("not-a-date")', sampleNote)).toBeUndefined();
+		});
+	});
+
+	describe("string methods", () => {
+		it(".contains() checks inclusion", () => {
+			expect(evaluate('author.contains("Fitz")', sampleNote)).toBe(true);
+			expect(evaluate('author.contains("Hem")', sampleNote)).toBe(false);
+		});
+
+		it(".lower() converts to lowercase", () => {
+			expect(evaluate("author.lower()", sampleNote)).toBe("fitzgerald");
+		});
+
+		it(".upper() converts to uppercase", () => {
+			expect(evaluate("author.upper()", sampleNote)).toBe("FITZGERALD");
+		});
+
+		it(".title() converts to title case", () => {
+			const note = {
+				...sampleNote,
+				metadata: { ...sampleNote.metadata, word: "hello world" },
+			};
+			expect(evaluate("word.title()", note)).toBe("Hello World");
+		});
+
+		it(".trim() removes whitespace", () => {
+			const note = {
+				...sampleNote,
+				metadata: { ...sampleNote.metadata, padded: "  hello  " },
+			};
+			expect(evaluate("padded.trim()", note)).toBe("hello");
+		});
+
+		it('.split() splits string by separator', () => {
+			expect(evaluate('author.split("g")', sampleNote)).toEqual([
+				"Fitz",
+				"erald",
+			]);
+		});
+
+		it(".replace() replaces substring", () => {
+			expect(evaluate('author.replace("gerald", "patrick")', sampleNote)).toBe(
+				"Fitzpatrick",
+			);
+		});
+
+		it(".startsWith() checks prefix", () => {
+			expect(evaluate('author.startsWith("Fitz")', sampleNote)).toBe(true);
+			expect(evaluate('author.startsWith("Hem")', sampleNote)).toBe(false);
+		});
+
+		it(".endsWith() checks suffix", () => {
+			expect(evaluate('author.endsWith("ald")', sampleNote)).toBe(true);
+		});
+
+		it(".slice() extracts substring", () => {
+			expect(evaluate("author.slice(0, 4)", sampleNote)).toBe("Fitz");
+		});
+
+		it(".length returns string length", () => {
+			expect(evaluate("author.length", sampleNote)).toBe(10);
+		});
+
+		it(".isEmpty() checks empty string", () => {
+			const note = {
+				...sampleNote,
+				metadata: { ...sampleNote.metadata, empty: "" },
+			};
+			expect(evaluate("empty.isEmpty()", note)).toBe(true);
+			expect(evaluate("author.isEmpty()", sampleNote)).toBe(false);
+		});
+
+		it(".isEmpty() returns true for missing property", () => {
+			expect(evaluate("nonexistent.isEmpty()", sampleNote)).toBe(true);
+		});
+	});
+
+	describe("number methods", () => {
+		it(".abs() returns absolute value", () => {
+			const note = {
+				...sampleNote,
+				metadata: { ...sampleNote.metadata, temp: -5 },
+			};
+			expect(evaluate("temp.abs()", note)).toBe(5);
+		});
+
+		it(".ceil() rounds up", () => {
+			expect(evaluate("rating.ceil()", sampleNote)).toBe(5);
+		});
+
+		it(".floor() rounds down", () => {
+			expect(evaluate("rating.floor()", sampleNote)).toBe(4);
+		});
+
+		it(".round() rounds to nearest integer", () => {
+			expect(evaluate("rating.round()", sampleNote)).toBe(5);
+		});
+
+		it(".round(digits) rounds to N digits", () => {
+			const note = {
+				...sampleNote,
+				metadata: { ...sampleNote.metadata, pi: 3.14159 },
+			};
+			expect(evaluate("pi.round(2)", note)).toBe(3.14);
+		});
+
+		it(".toFixed(precision) returns fixed-point string", () => {
+			expect(evaluate("rating.toFixed(2)", sampleNote)).toBe("4.50");
+		});
+
+		it(".isEmpty() returns false for numbers", () => {
+			expect(evaluate("year.isEmpty()", sampleNote)).toBe(false);
+		});
+	});
+
+	describe("list methods", () => {
+		it(".contains() checks array inclusion", () => {
+			expect(evaluate('file.tags.contains("fiction")', sampleNote)).toBe(true);
+			expect(evaluate('file.tags.contains("missing")', sampleNote)).toBe(false);
+		});
+
+		it(".containsAll() checks all present", () => {
+			expect(
+				evaluate(
+					'file.tags.containsAll("fiction", "classic")',
+					sampleNote,
+				),
+			).toBe(true);
+			expect(
+				evaluate(
+					'file.tags.containsAll("fiction", "missing")',
+					sampleNote,
+				),
+			).toBe(false);
+		});
+
+		it(".containsAny() checks any present", () => {
+			expect(
+				evaluate(
+					'file.tags.containsAny("fiction", "missing")',
+					sampleNote,
+				),
+			).toBe(true);
+			expect(
+				evaluate(
+					'file.tags.containsAny("missing1", "missing2")',
+					sampleNote,
+				),
+			).toBe(false);
+		});
+
+		it('.join() joins array elements', () => {
+			expect(evaluate('file.tags.join(", ")', sampleNote)).toBe(
+				"fiction, classic",
+			);
+		});
+
+		it(".sort() returns sorted array", () => {
+			expect(evaluate("file.tags.sort()", sampleNote)).toEqual([
+				"classic",
+				"fiction",
+			]);
+		});
+
+		it(".unique() removes duplicates", () => {
+			const note = {
+				...sampleNote,
+				metadata: { ...sampleNote.metadata, tags: ["a", "b", "a", "c"] },
+			};
+			expect(evaluate("file.tags.unique()", note)).toEqual(["a", "b", "c"]);
+		});
+
+		it(".flat() flattens nested arrays", () => {
+			const note = {
+				...sampleNote,
+				metadata: {
+					...sampleNote.metadata,
+					nested: [
+						[1, 2],
+						[3, 4],
+					],
+				},
+			};
+			expect(evaluate("nested.flat()", note)).toEqual([1, 2, 3, 4]);
+		});
+
+		it(".length returns array length", () => {
+			expect(evaluate("file.tags.length", sampleNote)).toBe(2);
+		});
+
+		it(".isEmpty() checks empty array", () => {
+			const note = {
+				...sampleNote,
+				metadata: { ...sampleNote.metadata, emptyArr: [] },
+			};
+			expect(evaluate("emptyArr.isEmpty()", note)).toBe(true);
+			expect(evaluate("file.tags.isEmpty()", sampleNote)).toBe(false);
+		});
+
+		it(".reverse() reverses array", () => {
+			expect(evaluate("file.tags.reverse()", sampleNote)).toEqual([
+				"classic",
+				"fiction",
+			]);
+		});
+
+		it(".slice() extracts subarray", () => {
+			expect(evaluate("file.tags.slice(0, 2)", sampleNote)).toEqual([
+				"fiction",
+				"classic",
+			]);
+		});
+	});
+
+	describe("date fields and methods", () => {
+		it(".year, .month, .day on Date", () => {
+			const result = evaluate('date("2024-06-15").year', sampleNote);
+			expect(result).toBe(2024);
+		});
+
+		it(".month on Date", () => {
+			const result = evaluate('date("2024-06-15").month', sampleNote);
+			expect(result).toBe(6);
+		});
+
+		it(".day on Date", () => {
+			const result = evaluate('date("2024-06-15").day', sampleNote);
+			expect(result).toBe(15);
+		});
+
+		it(".format() formats date", () => {
+			const result = evaluate(
+				'date("2024-06-15").format("YYYY-MM-DD")',
+				sampleNote,
+			);
+			expect(result).toBe("2024-06-15");
+		});
+
+		it(".isEmpty() returns false for dates", () => {
+			const result = evaluate('date("2024-06-15").isEmpty()', sampleNote);
+			expect(result).toBe(false);
+		});
+
+		it(".hour on Date returns hours", () => {
+			const note = {
+				...sampleNote,
+				metadata: {
+					...sampleNote.metadata,
+					ts: new Date(2024, 5, 15, 14, 30, 45),
+				},
+			};
+			expect(evaluate("ts.hour", note)).toBe(14);
+		});
+
+		it(".minute on Date returns minutes", () => {
+			const note = {
+				...sampleNote,
+				metadata: {
+					...sampleNote.metadata,
+					ts: new Date(2024, 5, 15, 14, 30, 45),
+				},
+			};
+			expect(evaluate("ts.minute", note)).toBe(30);
+		});
+
+		it(".second on Date returns seconds", () => {
+			const note = {
+				...sampleNote,
+				metadata: {
+					...sampleNote.metadata,
+					ts: new Date(2024, 5, 15, 14, 30, 45),
+				},
+			};
+			expect(evaluate("ts.second", note)).toBe(45);
+		});
+
+		it(".relative() on today's exact time returns 'today'", () => {
+			// Use current time so diffMs ≈ 0 ms → diffDays rounds to 0
+			const now = new Date();
+			const note = {
+				...sampleNote,
+				metadata: { ...sampleNote.metadata, now },
+			};
+			expect(evaluate("now.relative()", note)).toBe("today");
+		});
+
+		it(".relative() on a past date returns 'X days ago'", () => {
+			// Use exactly 10 * 24h ago to avoid rounding ambiguity
+			const past = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000);
+			const note = {
+				...sampleNote,
+				metadata: { ...sampleNote.metadata, past },
+			};
+			expect(evaluate("past.relative()", note)).toBe("10 days ago");
+		});
+
+		it(".relative() on a future date returns 'in X days'", () => {
+			// Use exactly 10 * 24h ahead to avoid rounding ambiguity
+			const future = new Date(Date.now() + 10 * 24 * 60 * 60 * 1000);
+			const note = {
+				...sampleNote,
+				metadata: { ...sampleNote.metadata, future },
+			};
+			expect(evaluate("future.relative()", note)).toBe("in 10 days");
+		});
+	});
+
+	describe("conditional expression", () => {
+		it("evaluates ternary", () => {
+			expect(evaluate('year > 2000 ? "new" : "old"', sampleNote)).toBe("old");
+			expect(evaluate('year < 2000 ? "old" : "new"', sampleNote)).toBe("old");
+		});
+	});
+
+	describe("array expression", () => {
+		it("evaluates array literal", () => {
+			expect(evaluate("[1, 2, 3]", sampleNote)).toEqual([1, 2, 3]);
+		});
+	});
+
+	describe("evalFilter convenience function", () => {
+		it("parses and evaluates, returns boolean", () => {
+			expect(evalFilter('author == "Fitzgerald"', sampleNote)).toBe(true);
+			expect(evalFilter("year > 2000", sampleNote)).toBe(false);
+		});
+
+		it("handles complex filter expressions", () => {
+			expect(
+				evalFilter(
+					'file.hasTag("fiction") && year < 2000',
+					sampleNote,
+				),
+			).toBe(true);
+		});
+
+		it("returns false for errors", () => {
+			expect(evalFilter("", sampleNote)).toBe(false);
+		});
+	});
+
+	describe("edge cases", () => {
+		it("handles null metadata values", () => {
+			const note = {
+				...sampleNote,
+				metadata: { ...sampleNote.metadata, nullVal: null },
+			};
+			expect(evaluate("nullVal", note)).toBeNull();
+		});
+
+		it("handles missing properties gracefully", () => {
+			expect(evaluate("missing", sampleNote)).toBeUndefined();
+		});
+
+		it("handles nested member access on metadata objects", () => {
+			const note = {
+				...sampleNote,
+				metadata: { ...sampleNote.metadata, nested: { deep: "value" } },
+			};
+			expect(evaluate("nested.deep", note)).toBe("value");
+		});
+
+		it("handles note with no __formulas", () => {
+			const note = { ...sampleNote, __formulas: undefined };
+			expect(evaluate("formula.readingTime", note, { readingTime: 10 })).toBe(
+				10,
+			);
+		});
+
+		it("handles note with no tags", () => {
+			const note = {
+				...sampleNote,
+				metadata: { ...sampleNote.metadata, tags: undefined },
+			};
+			expect(evaluate('file.hasTag("fiction")', note)).toBe(false);
+		});
+
+		it("file.folder for root-level file", () => {
+			const note = { ...sampleNote, path: "README.md" };
+			expect(evaluate("file.folder", note)).toBe("");
+		});
+	});
+
+	describe("dg-note-properties nested lookup", () => {
+		const nestedNote = {
+			path: "books/Dune.md",
+			url: "/notes/dune/",
+			metadata: {
+				"dg-publish": true,
+				permalink: "/notes/dune/",
+				tags: ["note"],
+				"dg-note-properties": {
+					author: "Frank Herbert",
+					year: 1965,
+					rating: 4.8,
+					date: "not a valid 11ty date",
+					status: "read",
+				},
+			},
+			fileSlug: "dune",
+		};
+
+		it("resolves identifier from nested dg-note-properties", () => {
+			expect(evaluate("author", nestedNote)).toBe("Frank Herbert");
+		});
+
+		it("resolves note.property from nested", () => {
+			expect(evaluate("note.year", nestedNote)).toBe(1965);
+		});
+
+		it("resolves property that would crash 11ty at top level (date)", () => {
+			expect(evaluate("date", nestedNote)).toBe("not a valid 11ty date");
+		});
+
+		it("file.hasProperty finds nested properties", () => {
+			expect(evaluate('file.hasProperty("author")', nestedNote)).toBe(true);
+			expect(evaluate('file.hasProperty("nonexistent")', nestedNote)).toBe(false);
+		});
+
+		it("evalFilter works with nested properties", () => {
+			expect(evalFilter('year > 1960', nestedNote)).toBe(true);
+			expect(evalFilter('status == "read"', nestedNote)).toBe(true);
+		});
+
+		it("falls back to top-level metadata when not in nested", () => {
+			expect(evaluate("permalink", nestedNote)).toBe("/notes/dune/");
+		});
+
+		it("nested takes precedence over top-level", () => {
+			const note = {
+				path: "test.md",
+				metadata: {
+					status: "top-level",
+					"dg-note-properties": { status: "nested" },
+				},
+			};
+			expect(evaluate("status", note)).toBe("nested");
+		});
+	});
+});

--- a/src/helpers/bases-engine/__tests__/exprParser.test.js
+++ b/src/helpers/bases-engine/__tests__/exprParser.test.js
@@ -1,0 +1,176 @@
+import { describe, it, expect } from "vitest";
+import { parseExpression } from "../exprParser.js";
+
+describe("parseExpression", () => {
+	describe("simple comparisons", () => {
+		it('parses status == "active"', () => {
+			const ast = parseExpression('status == "active"');
+			expect(ast.type).toBe("BinaryExpression");
+			expect(ast.operator).toBe("==");
+			expect(ast.left.name).toBe("status");
+			expect(ast.right.value).toBe("active");
+		});
+
+		it("parses year > 2020", () => {
+			const ast = parseExpression("year > 2020");
+			expect(ast.type).toBe("BinaryExpression");
+			expect(ast.operator).toBe(">");
+			expect(ast.left.name).toBe("year");
+			expect(ast.right.value).toBe(2020);
+		});
+
+		it("parses year != 2019", () => {
+			const ast = parseExpression("year != 2019");
+			expect(ast.type).toBe("BinaryExpression");
+			expect(ast.operator).toBe("!=");
+			expect(ast.left.name).toBe("year");
+			expect(ast.right.value).toBe(2019);
+		});
+
+		it("parses year >= 2020", () => {
+			const ast = parseExpression("year >= 2020");
+			expect(ast.type).toBe("BinaryExpression");
+			expect(ast.operator).toBe(">=");
+			expect(ast.left.name).toBe("year");
+			expect(ast.right.value).toBe(2020);
+		});
+
+		it("parses year <= 2020", () => {
+			const ast = parseExpression("year <= 2020");
+			expect(ast.type).toBe("BinaryExpression");
+			expect(ast.operator).toBe("<=");
+			expect(ast.left.name).toBe("year");
+			expect(ast.right.value).toBe(2020);
+		});
+	});
+
+	describe("member access", () => {
+		it("parses file.name", () => {
+			const ast = parseExpression("file.name");
+			expect(ast.type).toBe("MemberExpression");
+			expect(ast.object.name).toBe("file");
+			expect(ast.property.name).toBe("name");
+		});
+
+		it("parses file.folder", () => {
+			const ast = parseExpression("file.folder");
+			expect(ast.type).toBe("MemberExpression");
+			expect(ast.object.name).toBe("file");
+			expect(ast.property.name).toBe("folder");
+		});
+
+		it("parses note.author", () => {
+			const ast = parseExpression("note.author");
+			expect(ast.type).toBe("MemberExpression");
+			expect(ast.object.name).toBe("note");
+			expect(ast.property.name).toBe("author");
+		});
+	});
+
+	describe("function calls", () => {
+		it('parses file.inFolder("books")', () => {
+			const ast = parseExpression('file.inFolder("books")');
+			expect(ast.type).toBe("CallExpression");
+			expect(ast.callee.type).toBe("MemberExpression");
+			expect(ast.callee.object.name).toBe("file");
+			expect(ast.callee.property.name).toBe("inFolder");
+			expect(ast.arguments).toHaveLength(1);
+			expect(ast.arguments[0].value).toBe("books");
+		});
+
+		it('parses file.hasTag("fiction")', () => {
+			const ast = parseExpression('file.hasTag("fiction")');
+			expect(ast.type).toBe("CallExpression");
+			expect(ast.callee.property.name).toBe("hasTag");
+			expect(ast.arguments[0].value).toBe("fiction");
+		});
+
+		it('parses file.hasProperty("status")', () => {
+			const ast = parseExpression('file.hasProperty("status")');
+			expect(ast.type).toBe("CallExpression");
+			expect(ast.callee.property.name).toBe("hasProperty");
+			expect(ast.arguments[0].value).toBe("status");
+		});
+	});
+
+	describe("method calls", () => {
+		it('parses name.contains("test")', () => {
+			const ast = parseExpression('name.contains("test")');
+			expect(ast.type).toBe("CallExpression");
+			expect(ast.callee.object.name).toBe("name");
+			expect(ast.callee.property.name).toBe("contains");
+			expect(ast.arguments[0].value).toBe("test");
+		});
+
+		it("parses (price / age).toFixed(2)", () => {
+			const ast = parseExpression("(price / age).toFixed(2)");
+			expect(ast.type).toBe("CallExpression");
+			expect(ast.callee.type).toBe("MemberExpression");
+			expect(ast.callee.property.name).toBe("toFixed");
+			expect(ast.callee.object.type).toBe("BinaryExpression");
+			expect(ast.callee.object.operator).toBe("/");
+			expect(ast.arguments[0].value).toBe(2);
+		});
+	});
+
+	describe("boolean logic", () => {
+		it("parses a && b", () => {
+			const ast = parseExpression("a && b");
+			expect(ast.type).toBe("BinaryExpression");
+			expect(ast.operator).toBe("&&");
+			expect(ast.left.name).toBe("a");
+			expect(ast.right.name).toBe("b");
+		});
+
+		it("parses a || b", () => {
+			const ast = parseExpression("a || b");
+			expect(ast.type).toBe("BinaryExpression");
+			expect(ast.operator).toBe("||");
+			expect(ast.left.name).toBe("a");
+			expect(ast.right.name).toBe("b");
+		});
+
+		it("parses !a", () => {
+			const ast = parseExpression("!a");
+			expect(ast.type).toBe("UnaryExpression");
+			expect(ast.operator).toBe("!");
+			expect(ast.argument.name).toBe("a");
+		});
+	});
+
+	describe("complex expressions", () => {
+		it('parses status == "read" && year > 2020', () => {
+			const ast = parseExpression('status == "read" && year > 2020');
+			expect(ast.type).toBe("BinaryExpression");
+			expect(ast.operator).toBe("&&");
+			expect(ast.left.type).toBe("BinaryExpression");
+			expect(ast.left.operator).toBe("==");
+			expect(ast.right.type).toBe("BinaryExpression");
+			expect(ast.right.operator).toBe(">");
+		});
+	});
+
+	describe("error cases", () => {
+		it("throws on empty string", () => {
+			expect(() => parseExpression("")).toThrow();
+		});
+
+		it("throws on whitespace-only string", () => {
+			expect(() => parseExpression("   ")).toThrow();
+		});
+
+		it("throws on null", () => {
+			expect(() => parseExpression(null)).toThrow();
+		});
+
+		it("throws on undefined", () => {
+			expect(() => parseExpression(undefined)).toThrow();
+		});
+
+		it("throws on non-string input", () => {
+			expect(() => parseExpression(42)).toThrow();
+			expect(() => parseExpression({})).toThrow();
+			expect(() => parseExpression([])).toThrow();
+		});
+	});
+});

--- a/src/helpers/bases-engine/__tests__/queryEngine.test.js
+++ b/src/helpers/bases-engine/__tests__/queryEngine.test.js
@@ -1,0 +1,586 @@
+import { describe, it, expect } from "vitest";
+import { executeBaseQuery } from "../queryEngine.js";
+
+// Test fixture: 6 notes with varied properties
+const testNotes = [
+	{
+		path: "books/The Great Gatsby.md",
+		url: "/notes/the-great-gatsby/",
+		metadata: {
+			tags: ["book", "fiction", "classic"],
+			author: "F. Scott Fitzgerald",
+			year: 1925,
+			rating: 4.5,
+			genre: "Fiction",
+			wordCount: 47094,
+			status: "read",
+			favorite: true,
+		},
+		fileSlug: "the-great-gatsby",
+	},
+	{
+		path: "books/1984.md",
+		url: "/notes/1984/",
+		metadata: {
+			tags: ["book", "fiction", "dystopia"],
+			author: "George Orwell",
+			year: 1949,
+			rating: 4.8,
+			genre: "Fiction",
+			wordCount: 88942,
+			status: "read",
+			favorite: true,
+		},
+		fileSlug: "1984",
+	},
+	{
+		path: "books/Sapiens.md",
+		url: "/notes/sapiens/",
+		metadata: {
+			tags: ["book", "nonfiction"],
+			author: "Yuval Noah Harari",
+			year: 2011,
+			rating: 4.2,
+			genre: "Non-Fiction",
+			wordCount: 115000,
+			status: "read",
+			favorite: false,
+		},
+		fileSlug: "sapiens",
+	},
+	{
+		path: "books/Dune.md",
+		url: "/notes/dune/",
+		metadata: {
+			tags: ["book", "fiction", "scifi"],
+			author: "Frank Herbert",
+			year: 1965,
+			rating: 4.7,
+			genre: "Fiction",
+			wordCount: 188000,
+			status: "reading",
+			favorite: true,
+		},
+		fileSlug: "dune",
+	},
+	{
+		path: "books/Clean Code.md",
+		url: "/notes/clean-code/",
+		metadata: {
+			tags: ["book", "nonfiction", "tech"],
+			author: "Robert C. Martin",
+			year: 2008,
+			rating: 3.9,
+			genre: "Non-Fiction",
+			wordCount: 62000,
+			status: "read",
+			favorite: false,
+		},
+		fileSlug: "clean-code",
+	},
+	{
+		path: "notes/Random Note.md",
+		url: "/notes/random-note/",
+		metadata: {
+			tags: ["note"],
+			wordCount: 500,
+		},
+		fileSlug: "random-note",
+	},
+];
+
+describe("executeBaseQuery", () => {
+	describe("basic query", () => {
+		it("returns correct rows for a single table view", () => {
+			const yaml = `
+views:
+  - type: table
+    name: "All Notes"
+`;
+			const result = executeBaseQuery(yaml, testNotes);
+			expect(result.views).toHaveLength(1);
+			expect(result.views[0].config.type).toBe("table");
+			expect(result.views[0].config.name).toBe("All Notes");
+			expect(result.views[0].rows).toHaveLength(6);
+		});
+
+		it("returns properties from parsed query", () => {
+			const yaml = `
+properties:
+  status:
+    displayName: "Status"
+views:
+  - type: table
+    name: "Test"
+`;
+			const result = executeBaseQuery(yaml, testNotes);
+			expect(result.properties).toEqual({
+				status: { displayName: "Status" },
+			});
+		});
+	});
+
+	describe("filtering", () => {
+		it("filters by string expression (year > 1940)", () => {
+			const yaml = `
+filters:
+  - 'year > 1940'
+views:
+  - type: table
+    name: "Modern Books"
+`;
+			const result = executeBaseQuery(yaml, testNotes);
+			// 1949, 2011, 1965, 2008 pass; 1925 fails; random note has no year so undefined > 1940 = false
+			expect(result.views[0].rows).toHaveLength(4);
+			result.views[0].rows.forEach((row) => {
+				expect(row.metadata.year).toBeGreaterThan(1940);
+			});
+		});
+
+		it("filters by file.hasTag('fiction')", () => {
+			const yaml = `
+filters:
+  - 'file.hasTag("fiction")'
+views:
+  - type: table
+    name: "Fiction"
+`;
+			const result = executeBaseQuery(yaml, testNotes);
+			expect(result.views[0].rows).toHaveLength(3);
+			result.views[0].rows.forEach((row) => {
+				expect(row.metadata.tags).toContain("fiction");
+			});
+		});
+
+		it("filters with compound AND", () => {
+			const yaml = `
+filters:
+  and:
+    - 'file.hasTag("fiction")'
+    - 'year > 1940'
+views:
+  - type: table
+    name: "Modern Fiction"
+`;
+			const result = executeBaseQuery(yaml, testNotes);
+			// 1984 (1949) and Dune (1965) pass
+			expect(result.views[0].rows).toHaveLength(2);
+		});
+
+		it("filters with compound OR", () => {
+			const yaml = `
+filters:
+  or:
+    - 'year < 1930'
+    - 'year > 2000'
+views:
+  - type: table
+    name: "Old or New"
+`;
+			const result = executeBaseQuery(yaml, testNotes);
+			// Gatsby (1925), Sapiens (2011), Clean Code (2008)
+			expect(result.views[0].rows).toHaveLength(3);
+		});
+
+		it("filters with NOT", () => {
+			const yaml = `
+filters:
+  not:
+    - 'file.hasTag("fiction")'
+views:
+  - type: table
+    name: "Non-Fiction"
+`;
+			const result = executeBaseQuery(yaml, testNotes);
+			// Sapiens, Clean Code, Random Note
+			expect(result.views[0].rows).toHaveLength(3);
+		});
+
+		it("applies view-specific filters", () => {
+			const yaml = `
+filters:
+  - 'file.hasTag("book")'
+views:
+  - type: table
+    name: "High Rated Books"
+    filters:
+      - 'rating >= 4.5'
+`;
+			const result = executeBaseQuery(yaml, testNotes);
+			// Global: all books (5). View: rating >= 4.5 -> Gatsby(4.5), 1984(4.8), Dune(4.7)
+			expect(result.views[0].rows).toHaveLength(3);
+		});
+	});
+
+	describe("formulas", () => {
+		it("computes formula values and stores in __formulas", () => {
+			const yaml = `
+formulas:
+  readingTime: '(wordCount / 200)'
+views:
+  - type: table
+    name: "With Formulas"
+`;
+			const result = executeBaseQuery(yaml, testNotes);
+			const gatsby = result.views[0].rows.find(
+				(r) => r.fileSlug === "the-great-gatsby",
+			);
+			expect(gatsby.__formulas.readingTime).toBeCloseTo(47094 / 200);
+		});
+	});
+
+	describe("sorting", () => {
+		it("sorts by metadata field ASC", () => {
+			const yaml = `
+filters:
+  - 'file.hasTag("book")'
+views:
+  - type: table
+    name: "By Year"
+    sort:
+      - property: year
+        direction: ASC
+`;
+			const result = executeBaseQuery(yaml, testNotes);
+			const years = result.views[0].rows.map((r) => r.metadata.year);
+			expect(years).toEqual([1925, 1949, 1965, 2008, 2011]);
+		});
+
+		it("sorts by metadata field DESC", () => {
+			const yaml = `
+filters:
+  - 'file.hasTag("book")'
+views:
+  - type: table
+    name: "By Rating DESC"
+    sort:
+      - property: rating
+        direction: DESC
+`;
+			const result = executeBaseQuery(yaml, testNotes);
+			const ratings = result.views[0].rows.map((r) => r.metadata.rating);
+			expect(ratings).toEqual([4.8, 4.7, 4.5, 4.2, 3.9]);
+		});
+
+		it("sorts by file.name", () => {
+			const yaml = `
+filters:
+  - 'file.hasTag("book")'
+views:
+  - type: table
+    name: "By Name"
+    sort:
+      - property: file.name
+        direction: ASC
+`;
+			const result = executeBaseQuery(yaml, testNotes);
+			const names = result.views[0].rows.map((r) => {
+				const parts = r.path.split("/");
+				return parts[parts.length - 1].replace(/\.[^.]+$/, "");
+			});
+			expect(names).toEqual([
+				"1984",
+				"Clean Code",
+				"Dune",
+				"Sapiens",
+				"The Great Gatsby",
+			]);
+		});
+
+		it("sorts by formula value", () => {
+			const yaml = `
+filters:
+  - 'file.hasTag("book")'
+formulas:
+  readingTime: '(wordCount / 200)'
+views:
+  - type: table
+    name: "By Reading Time"
+    sort:
+      - property: formula.readingTime
+        direction: ASC
+`;
+			const result = executeBaseQuery(yaml, testNotes);
+			const times = result.views[0].rows.map(
+				(r) => r.__formulas.readingTime,
+			);
+			for (let i = 1; i < times.length; i++) {
+				expect(times[i]).toBeGreaterThanOrEqual(times[i - 1]);
+			}
+		});
+
+		it("sorts by multiple keys (genre ASC, rating DESC)", () => {
+			const yaml = `
+filters:
+  - 'file.hasTag("book")'
+views:
+  - type: table
+    name: "Multi-sort"
+    sort:
+      - property: genre
+        direction: ASC
+      - property: rating
+        direction: DESC
+`;
+			const result = executeBaseQuery(yaml, testNotes);
+			const rows = result.views[0].rows;
+			// Fiction group: 1984(4.8), Dune(4.7), Gatsby(4.5) — then Non-Fiction: Sapiens(4.2), Clean Code(3.9)
+			const genreRating = rows.map((r) => ({
+				genre: r.metadata.genre,
+				rating: r.metadata.rating,
+			}));
+			// All Fiction rows come before Non-Fiction rows
+			const fictionRows = genreRating.filter((r) => r.genre === "Fiction");
+			const nonFictionRows = genreRating.filter(
+				(r) => r.genre === "Non-Fiction",
+			);
+			expect(fictionRows.length).toBe(3);
+			expect(nonFictionRows.length).toBe(2);
+			// Within Fiction, rating is descending
+			const fictionRatings = fictionRows.map((r) => r.rating);
+			expect(fictionRatings).toEqual([4.8, 4.7, 4.5]);
+			// Within Non-Fiction, rating is descending
+			const nonFictionRatings = nonFictionRows.map((r) => r.rating);
+			expect(nonFictionRatings).toEqual([4.2, 3.9]);
+			// Fiction rows come before Non-Fiction in the combined result
+			const firstNonFictionIdx = rows.findIndex(
+				(r) => r.metadata.genre === "Non-Fiction",
+			);
+			const lastFictionIdx = rows.reduce(
+				(last, r, i) => (r.metadata.genre === "Fiction" ? i : last),
+				-1,
+			);
+			expect(lastFictionIdx).toBeLessThan(firstNonFictionIdx);
+		});
+
+		it("sorts using legacy order (first column ASC)", () => {
+			const yaml = `
+filters:
+  - 'file.hasTag("book")'
+views:
+  - type: table
+    name: "Legacy Order"
+    order: [year, author]
+`;
+			const result = executeBaseQuery(yaml, testNotes);
+			const years = result.views[0].rows.map((r) => r.metadata.year);
+			expect(years).toEqual([1925, 1949, 1965, 2008, 2011]);
+		});
+	});
+
+	describe("groupBy", () => {
+		it("groups rows by property value", () => {
+			const yaml = `
+filters:
+  - 'file.hasTag("book")'
+views:
+  - type: table
+    name: "By Genre"
+    groupBy:
+      property: genre
+`;
+			const result = executeBaseQuery(yaml, testNotes);
+			const view = result.views[0];
+			expect(view.groups).not.toBeNull();
+			expect(view.groups.length).toBeGreaterThanOrEqual(2);
+			const fictionGroup = view.groups.find((g) => g.key === "Fiction");
+			expect(fictionGroup.rows).toHaveLength(3);
+			const nonFictionGroup = view.groups.find(
+				(g) => g.key === "Non-Fiction",
+			);
+			expect(nonFictionGroup.rows).toHaveLength(2);
+		});
+
+		it("sorts groups by direction DESC", () => {
+			const yaml = `
+filters:
+  - 'file.hasTag("book")'
+views:
+  - type: table
+    name: "By Genre DESC"
+    groupBy:
+      property: genre
+      direction: DESC
+`;
+			const result = executeBaseQuery(yaml, testNotes);
+			const keys = result.views[0].groups.map((g) => g.key);
+			// DESC alphabetical: Non-Fiction before Fiction
+			expect(keys).toEqual(["Non-Fiction", "Fiction"]);
+		});
+	});
+
+	describe("limit", () => {
+		it("truncates rows to limit", () => {
+			const yaml = `
+views:
+  - type: table
+    name: "Limited"
+    limit: 3
+`;
+			const result = executeBaseQuery(yaml, testNotes);
+			expect(result.views[0].rows).toHaveLength(3);
+		});
+
+		it("limit applies after grouping (total rows)", () => {
+			const yaml = `
+filters:
+  - 'file.hasTag("book")'
+views:
+  - type: table
+    name: "Grouped Limited"
+    groupBy:
+      property: genre
+    limit: 3
+`;
+			const result = executeBaseQuery(yaml, testNotes);
+			const totalRows = result.views[0].groups.reduce(
+				(sum, g) => sum + g.rows.length,
+				0,
+			);
+			expect(totalRows).toBe(3);
+		});
+	});
+
+	describe("summaries", () => {
+		it("computes Average summary", () => {
+			const yaml = `
+filters:
+  - 'file.hasTag("book")'
+views:
+  - type: table
+    name: "With Summaries"
+    summaries:
+      rating: Average
+`;
+			const result = executeBaseQuery(yaml, testNotes);
+			const avg = (4.5 + 4.8 + 4.2 + 4.7 + 3.9) / 5;
+			expect(result.views[0].computedSummaries.rating).toBeCloseTo(avg);
+		});
+
+		it("computes Sum summary", () => {
+			const yaml = `
+filters:
+  - 'file.hasTag("book")'
+views:
+  - type: table
+    name: "Sum"
+    summaries:
+      wordCount: Sum
+`;
+			const result = executeBaseQuery(yaml, testNotes);
+			expect(result.views[0].computedSummaries.wordCount).toBe(
+				47094 + 88942 + 115000 + 188000 + 62000,
+			);
+		});
+
+		it("computes Min and Max summaries", () => {
+			const yaml = `
+filters:
+  - 'file.hasTag("book")'
+views:
+  - type: table
+    name: "MinMax"
+    summaries:
+      year: Min
+      rating: Max
+`;
+			const result = executeBaseQuery(yaml, testNotes);
+			expect(result.views[0].computedSummaries.year).toBe(1925);
+			expect(result.views[0].computedSummaries.rating).toBe(4.8);
+		});
+
+		it("computes Median summary", () => {
+			const yaml = `
+filters:
+  - 'file.hasTag("book")'
+views:
+  - type: table
+    name: "Median"
+    summaries:
+      rating: Median
+`;
+			const result = executeBaseQuery(yaml, testNotes);
+			// Sorted: 3.9, 4.2, 4.5, 4.7, 4.8 -> median = 4.5
+			expect(result.views[0].computedSummaries.rating).toBe(4.5);
+		});
+
+		it("computes Count summary", () => {
+			const yaml = `
+filters:
+  - 'file.hasTag("book")'
+views:
+  - type: table
+    name: "Count"
+    summaries:
+      author: Count
+`;
+			const result = executeBaseQuery(yaml, testNotes);
+			expect(result.views[0].computedSummaries.author).toBe(5);
+		});
+
+		it("computes Empty and Filled summaries", () => {
+			const yaml = `
+views:
+  - type: table
+    name: "EmptyFilled"
+    summaries:
+      author: Filled
+      genre: Empty
+`;
+			const result = executeBaseQuery(yaml, testNotes);
+			// 5 notes have author, 1 (Random Note) does not
+			expect(result.views[0].computedSummaries.author).toBe(5);
+			// 1 note has no genre (Random Note)
+			expect(result.views[0].computedSummaries.genre).toBe(1);
+		});
+
+		it("computes Unique summary", () => {
+			const yaml = `
+filters:
+  - 'file.hasTag("book")'
+views:
+  - type: table
+    name: "Unique"
+    summaries:
+      genre: Unique
+`;
+			const result = executeBaseQuery(yaml, testNotes);
+			// Fiction, Non-Fiction
+			expect(result.views[0].computedSummaries.genre).toBe(2);
+		});
+	});
+
+	describe("error handling", () => {
+		it("throws on missing views array", () => {
+			const yaml = `
+properties:
+  status:
+    displayName: "Status"
+`;
+			expect(() => executeBaseQuery(yaml, testNotes)).toThrow(/views/i);
+		});
+
+		it("throws on malformed YAML", () => {
+			const yaml = `
+  - ]: invalid
+  {{{}}}
+`;
+			expect(() => executeBaseQuery(yaml, testNotes)).toThrow();
+		});
+	});
+
+	describe("empty result set", () => {
+		it("returns empty rows when no notes match", () => {
+			const yaml = `
+filters:
+  - 'year > 9999'
+views:
+  - type: table
+    name: "Empty"
+`;
+			const result = executeBaseQuery(yaml, testNotes);
+			expect(result.views[0].rows).toHaveLength(0);
+			expect(result.views[0].groups).toBeNull();
+		});
+	});
+});

--- a/src/helpers/bases-engine/__tests__/views.test.js
+++ b/src/helpers/bases-engine/__tests__/views.test.js
@@ -1,0 +1,685 @@
+import { describe, it, expect } from "vitest";
+import { renderViews } from "../views.js";
+
+// Mock query result helpers
+function makeRow(name, url, metadata = {}, formulas = {}) {
+	return {
+		path: `books/${name}.md`,
+		url,
+		metadata,
+		__formulas: formulas,
+	};
+}
+
+const basicRows = [
+	makeRow("The Great Gatsby", "/notes/gatsby/", {
+		author: "F. Scott Fitzgerald",
+		year: 1925,
+		rating: 4.5,
+		genre: "Fiction",
+		favorite: true,
+	}),
+	makeRow("1984", "/notes/1984/", {
+		author: "George Orwell",
+		year: 1949,
+		rating: 4.8,
+		genre: "Fiction",
+		favorite: false,
+	}),
+	makeRow("Sapiens", "/notes/sapiens/", {
+		author: "Yuval Noah Harari",
+		year: 2011,
+		rating: 4.2,
+		genre: "Non-Fiction",
+		favorite: true,
+	}),
+];
+
+function makeQueryResult(views, properties = {}) {
+	return { properties, views };
+}
+
+function singleView(config, rows, groups = null, computedSummaries = {}) {
+	return { config, rows, groups, computedSummaries };
+}
+
+describe("renderViews", () => {
+	describe("table view", () => {
+		it("renders correct HTML structure (table, thead, tbody)", () => {
+			const result = renderViews(
+				makeQueryResult([
+					singleView(
+						{
+							type: "table",
+							name: "My Table",
+							order: ["file.name", "author", "year"],
+						},
+						basicRows,
+					),
+				]),
+			);
+			expect(result).toContain("<table");
+			expect(result).toContain("<thead>");
+			expect(result).toContain("<tbody>");
+			expect(result).toContain("</table>");
+			expect(result).toContain("obsidian-base-table-wrapper");
+		});
+
+		it("renders column headers from order", () => {
+			const result = renderViews(
+				makeQueryResult([
+					singleView(
+						{
+							type: "table",
+							name: "My Table",
+							order: ["file.name", "author", "year"],
+						},
+						basicRows,
+					),
+				]),
+			);
+			expect(result).toContain("<th>Name</th>");
+			expect(result).toContain("<th>Author</th>");
+			expect(result).toContain("<th>Year</th>");
+		});
+
+		it("renders summary bar when computedSummaries has values", () => {
+			const result = renderViews(
+				makeQueryResult([
+					singleView(
+						{
+							type: "table",
+							name: "With Summaries",
+							order: ["file.name", "author", "rating"],
+							summaries: { rating: "Average" },
+						},
+						basicRows,
+						null,
+						{ rating: 4.5 },
+					),
+				]),
+			);
+			expect(result).toContain("obsidian-base-summary-bar");
+			expect(result).toContain("4.5");
+			expect(result).toContain("Average");
+		});
+
+		it("does not render summary bar when no summaries", () => {
+			const result = renderViews(
+				makeQueryResult([
+					singleView(
+						{
+							type: "table",
+							name: "No Summaries",
+							order: ["file.name", "author"],
+						},
+						basicRows,
+					),
+				]),
+			);
+			expect(result).not.toContain("obsidian-base-summary-bar");
+		});
+	});
+
+	describe("file.name renders as internal link", () => {
+		it("renders file.name as anchor with internal-link class", () => {
+			const result = renderViews(
+				makeQueryResult([
+					singleView(
+						{
+							type: "table",
+							name: "Links",
+							order: ["file.name", "author"],
+						},
+						basicRows,
+					),
+				]),
+			);
+			expect(result).toContain(
+				'<a href="/notes/gatsby/" class="internal-link">The Great Gatsby</a>',
+			);
+			expect(result).toContain(
+				'<a href="/notes/1984/" class="internal-link">1984</a>',
+			);
+		});
+	});
+
+	describe("boolean values render as checkboxes", () => {
+		it("renders true as checked disabled checkbox", () => {
+			const result = renderViews(
+				makeQueryResult([
+					singleView(
+						{
+							type: "table",
+							name: "Booleans",
+							order: ["file.name", "favorite"],
+						},
+						basicRows,
+					),
+				]),
+			);
+			expect(result).toContain(
+				'<input type="checkbox" checked disabled />',
+			);
+			expect(result).toContain(
+				'<input type="checkbox" disabled />',
+			);
+		});
+	});
+
+	describe("array values", () => {
+		it("renders arrays joined with comma-space", () => {
+			const rows = [
+				makeRow("Test", "/notes/test/", {
+					tags: ["fiction", "classic"],
+				}),
+			];
+			const result = renderViews(
+				makeQueryResult([
+					singleView(
+						{
+							type: "table",
+							name: "Arrays",
+							order: ["file.name", "tags"],
+						},
+						rows,
+					),
+				]),
+			);
+			expect(result).toContain("fiction, classic");
+		});
+	});
+
+	describe("null/undefined values", () => {
+		it("renders null/undefined as empty string", () => {
+			const rows = [
+				makeRow("Test", "/notes/test/", { author: null }),
+			];
+			const result = renderViews(
+				makeQueryResult([
+					singleView(
+						{
+							type: "table",
+							name: "Nulls",
+							order: ["file.name", "author", "nonexistent"],
+						},
+						rows,
+					),
+				]),
+			);
+			// Should have empty <td></td> cells
+			expect(result).toMatch(/<td><\/td>/);
+		});
+	});
+
+	describe("HTML escaping", () => {
+		it("escapes HTML in values to prevent XSS", () => {
+			const rows = [
+				makeRow("Test", "/notes/test/", {
+					author: '<script>alert("xss")</script>',
+					title: "Tom & Jerry <3",
+				}),
+			];
+			const result = renderViews(
+				makeQueryResult([
+					singleView(
+						{
+							type: "table",
+							name: "Escape Test",
+							order: ["file.name", "author", "title"],
+						},
+						rows,
+					),
+				]),
+			);
+			expect(result).not.toContain("<script>");
+			expect(result).toContain("&lt;script&gt;");
+			expect(result).toContain("Tom &amp; Jerry &lt;3");
+		});
+
+		it("escapes HTML in file names", () => {
+			const rows = [
+				makeRow('<img src=x onerror=alert(1)>', "/notes/test/", {}),
+			];
+			const result = renderViews(
+				makeQueryResult([
+					singleView(
+						{
+							type: "table",
+							name: "Name Escape",
+							order: ["file.name"],
+						},
+						rows,
+					),
+				]),
+			);
+			expect(result).not.toContain("<img");
+			expect(result).toContain("&lt;img");
+		});
+	});
+
+	describe("column auto-detection", () => {
+		it("auto-detects columns from row data when no order specified", () => {
+			const rows = [
+				makeRow("Test", "/notes/test/", {
+					author: "Author1",
+					year: 2020,
+				}),
+			];
+			const result = renderViews(
+				makeQueryResult([
+					singleView({ type: "table", name: "Auto" }, rows),
+				]),
+			);
+			expect(result).toContain("<th>Name</th>");
+			expect(result).toContain("<th>Author</th>");
+			expect(result).toContain("<th>Year</th>");
+		});
+
+		it("skips internal keys (tags, dg-*, __formulas) in auto-detection", () => {
+			const rows = [
+				makeRow("Test", "/notes/test/", {
+					tags: ["a"],
+					"dg-publish": true,
+					author: "Someone",
+				}),
+			];
+			const result = renderViews(
+				makeQueryResult([
+					singleView({ type: "table", name: "Skip Internal" }, rows),
+				]),
+			);
+			expect(result).not.toContain("<th>Tags</th>");
+			expect(result).not.toContain("dg-publish");
+			expect(result).toContain("<th>Author</th>");
+		});
+	});
+
+	describe("display names from properties config", () => {
+		it("uses displayName from properties when available", () => {
+			const result = renderViews(
+				makeQueryResult(
+					[
+						singleView(
+							{
+								type: "table",
+								name: "DisplayNames",
+								order: ["file.name", "author", "year"],
+							},
+							basicRows,
+						),
+					],
+					{
+						author: { displayName: "Written By" },
+						year: { displayName: "Publication Year" },
+					},
+				),
+			);
+			expect(result).toContain("<th>Written By</th>");
+			expect(result).toContain("<th>Publication Year</th>");
+		});
+	});
+
+	describe("cards view", () => {
+		it("renders grid with correct style", () => {
+			const result = renderViews(
+				makeQueryResult([
+					singleView(
+						{
+							type: "cards",
+							name: "Cards",
+							order: ["file.name", "author", "year"],
+						},
+						basicRows,
+					),
+				]),
+			);
+			expect(result).toContain("obsidian-base-cards");
+			expect(result).toContain("grid-template-columns");
+			expect(result).toContain("minmax(200px");
+			expect(result).toContain("obsidian-base-card");
+		});
+
+		it("renders card titles as internal links", () => {
+			const result = renderViews(
+				makeQueryResult([
+					singleView(
+						{
+							type: "cards",
+							name: "Cards",
+							order: ["file.name", "author"],
+						},
+						basicRows,
+					),
+				]),
+			);
+			expect(result).toContain(
+				'<a href="/notes/gatsby/" class="internal-link">The Great Gatsby</a>',
+			);
+		});
+
+		it("renders with custom card size", () => {
+			const result = renderViews(
+				makeQueryResult([
+					singleView(
+						{
+							type: "cards",
+							name: "Cards",
+							cardSize: 300,
+							order: ["file.name"],
+						},
+						basicRows,
+					),
+				]),
+			);
+			expect(result).toContain("minmax(300px");
+		});
+
+		it("renders property label-value pairs", () => {
+			const result = renderViews(
+				makeQueryResult([
+					singleView(
+						{
+							type: "cards",
+							name: "Cards",
+							order: ["file.name", "author", "year"],
+						},
+						basicRows,
+					),
+				]),
+			);
+			expect(result).toContain("F. Scott Fitzgerald");
+			expect(result).toContain("1925");
+		});
+
+		it("renders image when config.image is set", () => {
+			const rows = [
+				makeRow("Test", "/notes/test/", {
+					cover: "/images/cover.jpg",
+					author: "Someone",
+				}),
+			];
+			const result = renderViews(
+				makeQueryResult([
+					singleView(
+						{
+							type: "cards",
+							name: "Cards",
+							image: "cover",
+							order: ["file.name", "author"],
+						},
+						rows,
+					),
+				]),
+			);
+			expect(result).toContain("<img");
+			expect(result).toContain("/images/cover.jpg");
+			expect(result).toContain("object-fit: cover");
+		});
+
+		it("applies custom imageFit and imageAspectRatio", () => {
+			const rows = [
+				makeRow("Test", "/notes/test/", {
+					cover: "/images/cover.jpg",
+				}),
+			];
+			const result = renderViews(
+				makeQueryResult([
+					singleView(
+						{
+							type: "cards",
+							name: "Cards",
+							image: "cover",
+							imageFit: "contain",
+							imageAspectRatio: 2,
+							order: ["file.name"],
+						},
+						rows,
+					),
+				]),
+			);
+			expect(result).toContain("object-fit: contain");
+			expect(result).toContain("aspect-ratio: 2");
+		});
+	});
+
+	describe("list view", () => {
+		it("renders ul/li structure", () => {
+			const result = renderViews(
+				makeQueryResult([
+					singleView(
+						{
+							type: "list",
+							name: "My List",
+							order: ["file.name", "author", "year"],
+						},
+						basicRows,
+					),
+				]),
+			);
+			expect(result).toContain("obsidian-base-list");
+			expect(result).toContain("<ul");
+			expect(result).toContain("<li>");
+			expect(result).toContain("</li>");
+		});
+
+		it("renders file.name as internal link in list", () => {
+			const result = renderViews(
+				makeQueryResult([
+					singleView(
+						{
+							type: "list",
+							name: "My List",
+							order: ["file.name", "author"],
+						},
+						basicRows,
+					),
+				]),
+			);
+			expect(result).toContain(
+				'<a href="/notes/gatsby/" class="internal-link">The Great Gatsby</a>',
+			);
+		});
+
+		it("joins property values with em dash", () => {
+			const result = renderViews(
+				makeQueryResult([
+					singleView(
+						{
+							type: "list",
+							name: "My List",
+							order: ["file.name", "author", "year"],
+						},
+						basicRows,
+					),
+				]),
+			);
+			expect(result).toContain(" — ");
+		});
+	});
+
+	describe("grouped view", () => {
+		it("renders group headers for all view types", () => {
+			const groups = [
+				{ key: "Fiction", rows: [basicRows[0], basicRows[1]] },
+				{ key: "Non-Fiction", rows: [basicRows[2]] },
+			];
+			const result = renderViews(
+				makeQueryResult([
+					singleView(
+						{
+							type: "table",
+							name: "Grouped",
+							order: ["file.name", "author"],
+						},
+						basicRows,
+						groups,
+					),
+				]),
+			);
+			expect(result).toContain("obsidian-base-group-row");
+			expect(result).toContain("obsidian-base-group-label");
+			expect(result).toContain("Fiction");
+			expect(result).toContain("Non-Fiction");
+		});
+
+		it("renders grouped cards view", () => {
+			const groups = [
+				{ key: "Fiction", rows: [basicRows[0]] },
+			];
+			const result = renderViews(
+				makeQueryResult([
+					singleView(
+						{
+							type: "cards",
+							name: "Grouped Cards",
+							order: ["file.name", "author"],
+						},
+						basicRows,
+						groups,
+					),
+				]),
+			);
+			expect(result).toContain("obsidian-base-group");
+			expect(result).toContain("obsidian-base-cards");
+		});
+
+		it("renders grouped list view", () => {
+			const groups = [
+				{ key: "Fiction", rows: [basicRows[0]] },
+			];
+			const result = renderViews(
+				makeQueryResult([
+					singleView(
+						{
+							type: "list",
+							name: "Grouped List",
+							order: ["file.name", "author"],
+						},
+						basicRows,
+						groups,
+					),
+				]),
+			);
+			expect(result).toContain("obsidian-base-group");
+			expect(result).toContain("obsidian-base-list");
+		});
+	});
+
+	describe("multi-view tab switcher", () => {
+		it("renders tab switcher when >1 view", () => {
+			const result = renderViews(
+				makeQueryResult([
+					singleView(
+						{
+							type: "table",
+							name: "Table View",
+							order: ["file.name"],
+						},
+						basicRows,
+					),
+					singleView(
+						{
+							type: "list",
+							name: "List View",
+							order: ["file.name"],
+						},
+						basicRows,
+					),
+				]),
+			);
+			expect(result).toContain("obsidian-bases-views");
+			expect(result).toContain("obsidian-bases-dropdown");
+			expect(result).toContain("obsidian-bases-active-view");
+			expect(result).toContain("Table View");
+			expect(result).toContain("List View");
+			expect(result).toContain('data-view-index="0"');
+			expect(result).toContain('data-view-index="1"');
+		});
+
+		it("does not render tab switcher for single view", () => {
+			const result = renderViews(
+				makeQueryResult([
+					singleView(
+						{
+							type: "table",
+							name: "Only View",
+							order: ["file.name"],
+						},
+						basicRows,
+					),
+				]),
+			);
+			expect(result).not.toContain("obsidian-bases-view-switcher");
+		});
+
+		it("first panel is visible, rest are hidden", () => {
+			const result = renderViews(
+				makeQueryResult([
+					singleView(
+						{
+							type: "table",
+							name: "View 1",
+							order: ["file.name"],
+						},
+						basicRows,
+					),
+					singleView(
+						{
+							type: "list",
+							name: "View 2",
+							order: ["file.name"],
+						},
+						basicRows,
+					),
+				]),
+			);
+			// First panel should not have display:none
+			const panels = result.match(
+				/obsidian-bases-view-panel[^>]*>/g,
+			);
+			expect(panels).toHaveLength(2);
+			// Second panel should be hidden
+			expect(result).toContain('style="display:none"');
+		});
+	});
+
+	describe("empty result", () => {
+		it("renders a message when no rows", () => {
+			const result = renderViews(
+				makeQueryResult([
+					singleView(
+						{
+							type: "table",
+							name: "Empty",
+							order: ["file.name"],
+						},
+						[],
+					),
+				]),
+			);
+			expect(result).toContain("No results");
+		});
+	});
+
+	describe("formula values in table", () => {
+		it("renders formula values from __formulas", () => {
+			const rows = [
+				makeRow("Test", "/notes/test/", { author: "A" }, { readingTime: 42 }),
+			];
+			const result = renderViews(
+				makeQueryResult([
+					singleView(
+						{
+							type: "table",
+							name: "Formulas",
+							order: ["file.name", "readingTime"],
+						},
+						rows,
+					),
+				]),
+			);
+			expect(result).toContain("42");
+		});
+	});
+});

--- a/src/helpers/bases-engine/exprEval.js
+++ b/src/helpers/bases-engine/exprEval.js
@@ -1,0 +1,502 @@
+const { parseExpression } = require("./exprParser");
+
+/**
+ * Get a user-defined property from note metadata.
+ * Checks "dg-note-properties" (nested/safe) first, then falls back
+ * to top-level metadata for backwards compatibility.
+ */
+function getUserProperty(metadata, key) {
+	if (!metadata) return undefined;
+	const nested = metadata["dg-note-properties"];
+	if (nested && key in nested) return nested[key];
+	if (key in metadata) return metadata[key];
+	return undefined;
+}
+
+/**
+ * Check if a user-defined property exists on the note.
+ */
+function hasUserProperty(metadata, key) {
+	if (!metadata) return false;
+	const nested = metadata["dg-note-properties"];
+	if (nested && key in nested) return true;
+	return key in metadata;
+}
+
+// Tags injected by the plugin that aren't real user tags
+const SYSTEM_TAGS = new Set(["note", "gardenEntry"]);
+
+/**
+ * Resolve a property name from a note's file metadata.
+ */
+function resolveFileProperty(prop, note) {
+	if (!note.path) return undefined;
+	switch (prop) {
+		case "name": {
+			const parts = note.path.split("/");
+			const filename = parts[parts.length - 1];
+			return filename.replace(/\.[^.]+$/, "");
+		}
+		case "path":
+			return note.path;
+		case "folder": {
+			const lastSlash = note.path.lastIndexOf("/");
+			return lastSlash === -1 ? "" : note.path.substring(0, lastSlash);
+		}
+		case "ext": {
+			const dotIdx = note.path.lastIndexOf(".");
+			return dotIdx === -1 ? "md" : note.path.substring(dotIdx + 1);
+		}
+		case "tags":
+			return ((note.metadata && note.metadata.tags) || []).filter((t) => !SYSTEM_TAGS.has(t));
+		case "links":
+			return note._links || (note.metadata && note.metadata.links) || [];
+		case "backlinks":
+			return note._backlinks || (note.metadata && note.metadata.backlinks) || [];
+		case "size":
+		case "ctime":
+		case "mtime":
+			return note.metadata ? note.metadata[prop] : undefined;
+		default:
+			return undefined;
+	}
+}
+
+/**
+ * Resolve a file filter function call.
+ */
+function resolveFileMethod(method, args, note) {
+	switch (method) {
+		case "hasTag": {
+			const tag = args[0];
+			const tags = (note.metadata && note.metadata.tags) || [];
+			const normalizedTag = tag.startsWith("#") ? tag.slice(1) : tag;
+			return tags.some(
+				(t) => t === normalizedTag || t === "#" + normalizedTag,
+			);
+		}
+		case "inFolder": {
+			const folder = args[0];
+			const normalised = String(folder).replace(/\/$/, "");
+			return note.path.startsWith(normalised + "/");
+		}
+		case "hasProperty": {
+			const prop = args[0];
+			return hasUserProperty(note.metadata, prop);
+		}
+		case "hasLink": {
+			const link = args[0];
+			const links = note._links || (note.metadata && note.metadata.links) || [];
+			// Check both full URL paths and stem paths
+			return links.some((l) => l === link || l.includes(link));
+		}
+		default:
+			return undefined;
+	}
+}
+
+/**
+ * Call a method on a resolved value (string, number, array, Date).
+ */
+function callMethod(obj, method, args) {
+	// isEmpty works on any type
+	if (method === "isEmpty") {
+		if (obj == null) return true;
+		if (typeof obj === "string") return obj === "";
+		if (Array.isArray(obj)) return obj.length === 0;
+		if (obj instanceof Date) return false;
+		if (typeof obj === "number") return false;
+		return false;
+	}
+
+	// String methods
+	if (typeof obj === "string") {
+		switch (method) {
+			case "contains":
+				return obj.includes(args[0]);
+			case "lower":
+				return obj.toLowerCase();
+			case "upper":
+				return obj.toUpperCase();
+			case "title":
+				return obj.replace(
+					/\b\w/g,
+					(c) => c.toUpperCase(),
+				);
+			case "trim":
+				return obj.trim();
+			case "split":
+				return obj.split(args[0]);
+			case "replace":
+				return obj.replace(args[0], args[1]);
+			case "startsWith":
+				return obj.startsWith(args[0]);
+			case "endsWith":
+				return obj.endsWith(args[0]);
+			case "slice":
+				return args.length > 1
+					? obj.slice(args[0], args[1])
+					: obj.slice(args[0]);
+		}
+	}
+
+	// Number methods
+	if (typeof obj === "number") {
+		switch (method) {
+			case "abs":
+				return Math.abs(obj);
+			case "ceil":
+				return Math.ceil(obj);
+			case "floor":
+				return Math.floor(obj);
+			case "round": {
+				if (args.length > 0 && args[0] != null) {
+					const factor = Math.pow(10, args[0]);
+					return Math.round(obj * factor) / factor;
+				}
+				return Math.round(obj);
+			}
+			case "toFixed":
+				return obj.toFixed(args[0]);
+		}
+	}
+
+	// Array methods
+	if (Array.isArray(obj)) {
+		switch (method) {
+			case "contains":
+				return obj.includes(args[0]);
+			case "containsAll":
+				return args.every((a) => obj.includes(a));
+			case "containsAny":
+				return args.some((a) => obj.includes(a));
+			case "join":
+				return obj.join(args[0]);
+			case "sort":
+				return [...obj].sort();
+			case "unique":
+				return [...new Set(obj)];
+			case "flat":
+				return obj.flat();
+			case "reverse":
+				return [...obj].reverse();
+			case "slice":
+				return args.length > 1
+					? obj.slice(args[0], args[1])
+					: obj.slice(args[0]);
+		}
+	}
+
+	// Date methods
+	if (obj instanceof Date) {
+		switch (method) {
+			case "format": {
+				const fmt = args[0] || "YYYY-MM-DD";
+				return fmt
+					.replace("YYYY", String(obj.getFullYear()))
+					.replace("MM", String(obj.getMonth() + 1).padStart(2, "0"))
+					.replace("DD", String(obj.getDate()).padStart(2, "0"))
+					.replace("HH", String(obj.getHours()).padStart(2, "0"))
+					.replace("mm", String(obj.getMinutes()).padStart(2, "0"))
+					.replace("ss", String(obj.getSeconds()).padStart(2, "0"));
+			}
+			// falls through not possible due to return above
+			case "date":
+				return new Date(
+					obj.getFullYear(),
+					obj.getMonth(),
+					obj.getDate(),
+				);
+			case "relative": {
+				const now = new Date();
+				const diffMs = now - obj;
+				const diffDays = Math.round(diffMs / (1000 * 60 * 60 * 24));
+				if (diffDays === 0) return "today";
+				if (diffDays === 1) return "1 day ago";
+				if (diffDays > 0) return diffDays + " days ago";
+				if (diffDays === -1) return "in 1 day";
+				return "in " + Math.abs(diffDays) + " days";
+			}
+		}
+	}
+
+	return undefined;
+}
+
+/**
+ * Resolve a property access on a value (for .length and date fields).
+ */
+function resolveProperty(obj, prop) {
+	if (prop === "length") {
+		if (typeof obj === "string" || Array.isArray(obj)) return obj.length;
+	}
+
+	if (obj instanceof Date) {
+		switch (prop) {
+			case "year":
+				return obj.getFullYear();
+			case "month":
+				return obj.getMonth() + 1;
+			case "day":
+				return obj.getDate();
+			case "hour":
+				return obj.getHours();
+			case "minute":
+				return obj.getMinutes();
+			case "second":
+				return obj.getSeconds();
+		}
+	}
+
+	// Generic object property access
+	if (obj != null && typeof obj === "object" && prop in obj) {
+		return obj[prop];
+	}
+
+	return undefined;
+}
+
+/**
+ * Evaluate a jsep AST node against a note data object.
+ * @param {object} ast - The jsep AST node
+ * @param {object} note - The note data object
+ * @param {object} formulas - External formulas map
+ * @param {object} context - Additional evaluation context
+ * @returns {*} The evaluated result
+ */
+function evalExpr(ast, note, formulas, context) {
+	if (!ast) return undefined;
+	formulas = formulas || {};
+	context = context || {};
+
+	switch (ast.type) {
+		case "Literal":
+			return ast.value;
+
+		case "Identifier": {
+			const name = ast.name;
+			if (name === "true") return true;
+			if (name === "false") return false;
+			if (name === "null") return null;
+			if (name === "undefined") return undefined;
+			// Look up in user properties, then metadata
+			return getUserProperty(note.metadata, name);
+		}
+
+		case "MemberExpression": {
+			const prop = ast.computed
+				? evalExpr(ast.property, note, formulas, context)
+				: ast.property.name;
+
+			// Check if object is a special identifier
+			if (ast.object.type === "Identifier") {
+				const objName = ast.object.name;
+				if (objName === "file") {
+					return resolveFileProperty(prop, note);
+				}
+				if (objName === "note") {
+					return getUserProperty(note.metadata, prop);
+				}
+				if (objName === "formula") {
+					if (note.__formulas && note.__formulas[prop] !== undefined) {
+						return note.__formulas[prop];
+					}
+					return formulas[prop];
+				}
+			}
+
+			// General member expression: evaluate object first
+			const obj = evalExpr(ast.object, note, formulas, context);
+			return resolveProperty(obj, prop);
+		}
+
+		case "CallExpression": {
+			// Check for file.method() pattern
+			if (
+				ast.callee.type === "MemberExpression" &&
+				ast.callee.object.type === "Identifier" &&
+				ast.callee.object.name === "file"
+			) {
+				const method = ast.callee.property.name;
+				const fileMethods = [
+					"hasTag",
+					"inFolder",
+					"hasProperty",
+					"hasLink",
+				];
+				if (fileMethods.includes(method)) {
+					const args = ast.arguments.map((a) =>
+						evalExpr(a, note, formulas, context),
+					);
+					return resolveFileMethod(method, args, note);
+				}
+			}
+
+			// Check for global functions
+			if (ast.callee.type === "Identifier") {
+				const funcName = ast.callee.name;
+				const args = ast.arguments.map((a) =>
+					evalExpr(a, note, formulas, context),
+				);
+				return callGlobalFunction(funcName, args);
+			}
+
+			// Method call on a value: obj.method(args)
+			if (ast.callee.type === "MemberExpression") {
+				const obj = evalExpr(ast.callee.object, note, formulas, context);
+				const method = ast.callee.computed
+					? evalExpr(ast.callee.property, note, formulas, context)
+					: ast.callee.property.name;
+				const args = ast.arguments.map((a) =>
+					evalExpr(a, note, formulas, context),
+				);
+
+				// Handle isEmpty on undefined/null
+				if (method === "isEmpty" && obj == null) return true;
+
+				return callMethod(obj, method, args);
+			}
+
+			return undefined;
+		}
+
+		case "BinaryExpression": {
+			// Short-circuit for logical operators
+			if (ast.operator === "&&") {
+				return (
+					evalExpr(ast.left, note, formulas, context) &&
+					evalExpr(ast.right, note, formulas, context)
+				);
+			}
+			if (ast.operator === "||") {
+				return (
+					evalExpr(ast.left, note, formulas, context) ||
+					evalExpr(ast.right, note, formulas, context)
+				);
+			}
+
+			const left = evalExpr(ast.left, note, formulas, context);
+			const right = evalExpr(ast.right, note, formulas, context);
+
+			switch (ast.operator) {
+				/* eslint-disable eqeqeq */
+				case "==":
+					return left == right;
+				case "!=":
+					return left != right;
+				/* eslint-enable eqeqeq */
+				case ">":
+					return left > right;
+				case "<":
+					return left < right;
+				case ">=":
+					return left >= right;
+				case "<=":
+					return left <= right;
+				case "+":
+					return left + right;
+				case "-":
+					return left - right;
+				case "*":
+					return left * right;
+				case "/":
+					if (right === 0) return undefined;
+					return left / right;
+				case "%":
+					return left % right;
+				default:
+					return undefined;
+			}
+		}
+
+		case "UnaryExpression": {
+			const arg = evalExpr(ast.argument, note, formulas, context);
+			switch (ast.operator) {
+				case "!":
+					return !arg;
+				case "-":
+					return -arg;
+				default:
+					return undefined;
+			}
+		}
+
+		case "ConditionalExpression": {
+			const test = evalExpr(ast.test, note, formulas, context);
+			return test
+				? evalExpr(ast.consequent, note, formulas, context)
+				: evalExpr(ast.alternate, note, formulas, context);
+		}
+
+		case "ArrayExpression": {
+			return ast.elements.map((el) =>
+				evalExpr(el, note, formulas, context),
+			);
+		}
+
+		case "Compound": {
+			// Evaluate all expressions, return last
+			let result;
+			for (const expr of ast.body) {
+				result = evalExpr(expr, note, formulas, context);
+			}
+			return result;
+		}
+
+		default:
+			return undefined;
+	}
+}
+
+/**
+ * Call a global function by name.
+ */
+function callGlobalFunction(name, args) {
+	switch (name) {
+		case "today": {
+			const d = new Date();
+			d.setHours(0, 0, 0, 0);
+			d._basesType = "today";
+			return d;
+		}
+		case "now": {
+			const d = new Date();
+			d._basesType = "now";
+			return d;
+		}
+		case "date": {
+			const d = new Date(args[0]);
+			return isNaN(d.getTime()) ? undefined : d;
+		}
+		case "if":
+			return args[0] ? args[1] : args[2];
+		case "number":
+			return Number(args[0]);
+		case "min":
+			return Math.min(...args);
+		case "max":
+			return Math.max(...args);
+		case "list":
+			return args.length === 1 && Array.isArray(args[0]) ? args[0] : args.length === 1 ? [args[0]] : args;
+		default:
+			return undefined;
+	}
+}
+
+/**
+ * Convenience function: parse expression string and evaluate as boolean filter.
+ * @param {string} expression - The expression string
+ * @param {object} note - The note data object
+ * @param {object} formulas - External formulas map
+ * @returns {boolean}
+ */
+function evalFilter(expression, note, formulas) {
+	try {
+		const ast = parseExpression(expression);
+		return Boolean(evalExpr(ast, note, formulas || {}));
+	} catch {
+		return false;
+	}
+}
+
+module.exports = { evalExpr, evalFilter };

--- a/src/helpers/bases-engine/exprParser.js
+++ b/src/helpers/bases-engine/exprParser.js
@@ -1,0 +1,23 @@
+const jsep = require("jsep");
+
+/**
+ * Parse an expression string into a jsep AST.
+ * @param {string} expression - The expression to parse
+ * @returns {object} The jsep AST node
+ * @throws {Error} If input is empty or not a string
+ */
+function parseExpression(expression) {
+	if (typeof expression !== "string") {
+		throw new Error("Expression must be a string");
+	}
+	if (expression.trim() === "") {
+		throw new Error("Expression must not be empty");
+	}
+	try {
+		return jsep(expression);
+	} catch (err) {
+		throw new Error('Failed to parse expression "' + expression + '": ' + err.message);
+	}
+}
+
+module.exports = { parseExpression };

--- a/src/helpers/bases-engine/index.js
+++ b/src/helpers/bases-engine/index.js
@@ -1,0 +1,6 @@
+const { parseExpression } = require("./exprParser");
+const { evalExpr, evalFilter } = require("./exprEval");
+const { executeBaseQuery } = require("./queryEngine");
+const { renderViews } = require("./views");
+
+module.exports = { parseExpression, evalExpr, evalFilter, executeBaseQuery, renderViews };

--- a/src/helpers/bases-engine/queryEngine.js
+++ b/src/helpers/bases-engine/queryEngine.js
@@ -1,0 +1,409 @@
+const yaml = require("yaml");
+const { parseExpression } = require("./exprParser");
+const { evalExpr, evalFilter } = require("./exprEval");
+
+/**
+ * Get a user property from metadata, checking "dg-note-properties" first.
+ */
+function getUserProperty(metadata, key) {
+	if (!metadata) return undefined;
+	const nested = metadata["dg-note-properties"];
+	if (nested && key in nested) return nested[key];
+	if (key in metadata) return metadata[key];
+	return undefined;
+}
+
+/**
+ * Execute a base query against an array of notes.
+ * @param {string} yamlContent - YAML query string
+ * @param {Array} notes - Array of note objects
+ * @returns {object} Structured result with properties and views
+ */
+function executeBaseQuery(yamlContent, notes) {
+	let parsed;
+	try {
+		parsed = yaml.parse(yamlContent);
+	} catch (err) {
+		throw new Error("Failed to parse YAML: " + err.message);
+	}
+
+	if (!parsed || !Array.isArray(parsed.views) || parsed.views.length === 0) {
+		throw new Error("Query must contain a 'views' array with at least one view");
+	}
+
+	const globalFilters = parsed.filters || null;
+	const formulas = parsed.formulas || {};
+	const properties = parsed.properties || {};
+	const globalSummaries = parsed.summaries || {};
+
+	const views = parsed.views.map((viewDef) => {
+		return processView(viewDef, notes, globalFilters, formulas, globalSummaries);
+	});
+
+	return { properties, views };
+}
+
+/**
+ * Process a single view definition.
+ */
+function processView(viewDef, notes, globalFilters, formulas, globalSummaries) {
+	const config = {
+		type: viewDef.type || "table",
+		name: viewDef.name || "Untitled",
+		limit: viewDef.limit != null ? viewDef.limit : null,
+		groupBy: viewDef.groupBy || null,
+		order: viewDef.order || null,
+		sort: viewDef.sort || null,
+		summaries: viewDef.summaries || null,
+		// Cards-specific options
+		image: viewDef.image || null,
+		imageFit: viewDef.imageFit || null,
+		imageAspectRatio: viewDef.imageAspectRatio || null,
+		cardSize: viewDef.cardSize || null,
+		// Table-specific options
+		rowHeight: viewDef.rowHeight || null,
+	};
+
+	// 1. Compute formulas
+	// Parse each formula expression once (not once per note)
+	const parsedFormulas = Object.entries(formulas).map(([key, expr]) => {
+		try {
+			return [key, parseExpression(expr)];
+		} catch {
+			return [key, null];
+		}
+	});
+
+	let rows = notes.map((note) => {
+		const computed = {};
+		for (const [key, ast] of parsedFormulas) {
+			try {
+				computed[key] = ast ? evalExpr(ast, note, {}) : undefined;
+			} catch {
+				computed[key] = undefined;
+			}
+		}
+		return { ...note, __formulas: computed };
+	});
+
+	// 2. Apply global filters
+	if (globalFilters) {
+		rows = applyFilterBlock(rows, globalFilters);
+	}
+
+	// 3. Apply view-level filters
+	if (viewDef.filters) {
+		rows = applyFilterBlock(rows, viewDef.filters);
+	}
+
+	// 4. Sort
+	rows = applySorting(rows, config);
+
+	// 5. Group
+	let groups = null;
+	if (config.groupBy) {
+		groups = applyGrouping(rows, config.groupBy);
+	}
+
+	// 6. Limit
+	if (config.limit) {
+		if (groups) {
+			groups = applyGroupLimit(groups, config.limit);
+			// Update rows to match grouped content
+			rows = groups.flatMap((g) => g.rows);
+		} else {
+			rows = rows.slice(0, config.limit);
+		}
+	}
+
+	// 7. Compute summaries
+	const computedSummaries = computeSummaries(rows, config.summaries);
+
+	return {
+		config,
+		rows,
+		groups,
+		computedSummaries,
+	};
+}
+
+// Cache parsed filter ASTs so the same expression string isn't re-parsed per note
+const filterASTCache = new Map();
+
+function getCachedAST(expression) {
+	if (filterASTCache.has(expression)) return filterASTCache.get(expression);
+	try {
+		const ast = parseExpression(expression);
+		filterASTCache.set(expression, ast);
+		return ast;
+	} catch {
+		filterASTCache.set(expression, null);
+		return null;
+	}
+}
+
+/**
+ * Apply a filter block (array or object with and/or/not) to rows.
+ */
+function applyFilterBlock(rows, filterBlock) {
+	return rows.filter((note) => matchesFilter(note, filterBlock));
+}
+
+/**
+ * Check if a note matches a filter block.
+ * Supports: string expression, array (implicit AND), { and: [...] }, { or: [...] }, { not: [...] }
+ */
+function matchesFilter(note, filterBlock) {
+	if (typeof filterBlock === "string") {
+		const ast = getCachedAST(filterBlock);
+		if (!ast) return false;
+		try {
+			return Boolean(evalExpr(ast, note, note.__formulas || {}));
+		} catch {
+			return false;
+		}
+	}
+
+	if (Array.isArray(filterBlock)) {
+		// Implicit AND
+		return filterBlock.every((f) => matchesFilter(note, f));
+	}
+
+	if (typeof filterBlock === "object" && filterBlock !== null) {
+		if (filterBlock.and) {
+			return filterBlock.and.every((f) => matchesFilter(note, f));
+		}
+		if (filterBlock.or) {
+			return filterBlock.or.some((f) => matchesFilter(note, f));
+		}
+		if (filterBlock.not) {
+			const subFilters = Array.isArray(filterBlock.not)
+				? filterBlock.not
+				: [filterBlock.not];
+			return !subFilters.some((f) => matchesFilter(note, f));
+		}
+	}
+
+	return true;
+}
+
+/**
+ * Get a sortable value for a property path from a note.
+ */
+function getSortValue(note, property) {
+	if (property === "file.name") {
+		const parts = (note.path || "").split("/");
+		return parts[parts.length - 1].replace(/\.[^.]+$/, "");
+	}
+	if (property.startsWith("file.")) {
+		const prop = property.slice(5);
+		// Reuse the simple file property resolution
+		switch (prop) {
+			case "path":
+				return note.path || "";
+			case "folder": {
+				const idx = (note.path || "").lastIndexOf("/");
+				return idx === -1 ? "" : (note.path || "").substring(0, idx);
+			}
+			default:
+				return getUserProperty(note.metadata, prop);
+		}
+	}
+	if (property.startsWith("formula.")) {
+		const formulaKey = property.slice(8);
+		return note.__formulas ? note.__formulas[formulaKey] : undefined;
+	}
+	return getUserProperty(note.metadata, property);
+}
+
+/**
+ * Apply sorting to rows based on view config.
+ */
+function applySorting(rows, config) {
+	if (config.sort && Array.isArray(config.sort) && config.sort.length > 0) {
+		return [...rows].sort((a, b) => {
+			for (const sortDef of config.sort) {
+				const prop = sortDef.property;
+				const dir = (sortDef.direction || "ASC").toUpperCase() === "DESC" ? -1 : 1;
+				const valA = getSortValue(a, prop);
+				const valB = getSortValue(b, prop);
+				const cmp = compareValues(valA, valB);
+				if (cmp !== 0) return cmp * dir;
+			}
+			return 0;
+		});
+	}
+
+	// Legacy order: sort by first column ASC
+	if (config.order && Array.isArray(config.order) && config.order.length > 0) {
+		const firstProp = config.order[0];
+		return [...rows].sort((a, b) => {
+			const valA = getSortValue(a, firstProp);
+			const valB = getSortValue(b, firstProp);
+			return compareValues(valA, valB);
+		});
+	}
+
+	return rows;
+}
+
+/**
+ * Compare two values for sorting.
+ */
+function compareValues(a, b) {
+	if (a == null && b == null) return 0;
+	if (a == null) return 1;
+	if (b == null) return -1;
+	if (typeof a === "string" && typeof b === "string") {
+		return a.localeCompare(b);
+	}
+	if (a < b) return -1;
+	if (a > b) return 1;
+	return 0;
+}
+
+/**
+ * Group rows by a property, optionally sorting groups.
+ */
+function applyGrouping(rows, groupByDef) {
+	const prop = groupByDef.property;
+	const direction = (groupByDef.direction || "ASC").toUpperCase();
+
+	const groupMap = new Map();
+	for (const row of rows) {
+		const key = getSortValue(row, prop);
+		const keyStr = key != null ? String(key) : "(empty)";
+		if (!groupMap.has(keyStr)) {
+			groupMap.set(keyStr, []);
+		}
+		groupMap.get(keyStr).push(row);
+	}
+
+	let groups = Array.from(groupMap.entries()).map(([key, groupRows]) => ({
+		key,
+		rows: groupRows,
+	}));
+
+	// Sort groups by key
+	groups.sort((a, b) => {
+		const cmp = compareValues(a.key, b.key);
+		return direction === "DESC" ? -cmp : cmp;
+	});
+
+	return groups;
+}
+
+/**
+ * Apply limit to grouped rows (total row count across groups).
+ */
+function applyGroupLimit(groups, limit) {
+	let remaining = limit;
+	const result = [];
+	for (const group of groups) {
+		if (remaining <= 0) break;
+		if (group.rows.length <= remaining) {
+			result.push(group);
+			remaining -= group.rows.length;
+		} else {
+			result.push({ key: group.key, rows: group.rows.slice(0, remaining) });
+			remaining = 0;
+		}
+	}
+	return result;
+}
+
+/**
+ * Compute summary values for the given rows.
+ */
+function computeSummaries(rows, summaryDefs) {
+	if (!summaryDefs) return {};
+
+	const result = {};
+	for (const [prop, summaryType] of Object.entries(summaryDefs)) {
+		const values = rows.map((r) => getSortValue(r, prop));
+		result[prop] = computeSingleSummary(values, summaryType);
+	}
+	return result;
+}
+
+/**
+ * Compute a single summary given an array of values and a summary type.
+ */
+function computeSingleSummary(values, summaryType) {
+	const type = typeof summaryType === "string" ? summaryType : String(summaryType);
+
+	switch (type) {
+		case "Average": {
+			const nums = values.filter((v) => typeof v === "number" && !isNaN(v));
+			if (nums.length === 0) return null;
+			return nums.reduce((a, b) => a + b, 0) / nums.length;
+		}
+		case "Sum": {
+			const nums = values.filter((v) => typeof v === "number" && !isNaN(v));
+			return nums.reduce((a, b) => a + b, 0);
+		}
+		case "Min": {
+			const nums = values.filter((v) => typeof v === "number" && !isNaN(v));
+			if (nums.length === 0) return null;
+			return Math.min(...nums);
+		}
+		case "Max": {
+			const nums = values.filter((v) => typeof v === "number" && !isNaN(v));
+			if (nums.length === 0) return null;
+			return Math.max(...nums);
+		}
+		case "Range": {
+			const nums = values.filter((v) => typeof v === "number" && !isNaN(v));
+			if (nums.length === 0) return null;
+			return Math.max(...nums) - Math.min(...nums);
+		}
+		case "Median": {
+			const nums = values
+				.filter((v) => typeof v === "number" && !isNaN(v))
+				.sort((a, b) => a - b);
+			if (nums.length === 0) return null;
+			const mid = Math.floor(nums.length / 2);
+			return nums.length % 2 === 0
+				? (nums[mid - 1] + nums[mid]) / 2
+				: nums[mid];
+		}
+		case "Stddev": {
+			const nums = values.filter((v) => typeof v === "number" && !isNaN(v));
+			if (nums.length === 0) return null;
+			const mean = nums.reduce((a, b) => a + b, 0) / nums.length;
+			const variance =
+				nums.reduce((sum, v) => sum + (v - mean) ** 2, 0) / nums.length;
+			return Math.sqrt(variance);
+		}
+		case "Earliest": {
+			const dates = values.filter((v) => v instanceof Date);
+			if (dates.length === 0) return null;
+			return new Date(Math.min(...dates.map((d) => d.getTime())));
+		}
+		case "Latest": {
+			const dates = values.filter((v) => v instanceof Date);
+			if (dates.length === 0) return null;
+			return new Date(Math.max(...dates.map((d) => d.getTime())));
+		}
+		case "Checked":
+			return values.filter((v) => v === true).length;
+		case "Unchecked":
+			return values.filter((v) => v === false).length;
+		case "Empty":
+			return values.filter(
+				(v) => v == null || v === "" || (Array.isArray(v) && v.length === 0),
+			).length;
+		case "Filled":
+			return values.filter(
+				(v) => v != null && v !== "" && !(Array.isArray(v) && v.length === 0),
+			).length;
+		case "Unique":
+			return new Set(values.filter((v) => v != null)).size;
+		case "Count":
+			return values.length;
+		default:
+			return null;
+	}
+}
+
+module.exports = { executeBaseQuery };

--- a/src/helpers/bases-engine/views.js
+++ b/src/helpers/bases-engine/views.js
@@ -1,0 +1,543 @@
+/**
+ * View renderers for bases query results.
+ * Generates static HTML for table, cards, and list views.
+ */
+
+// --- Metadata helpers ---
+
+/**
+ * Get a user property from metadata. Checks "dg-note-properties"
+ * (nested/safe) first, then falls back to top-level metadata.
+ */
+function getMetaValue(metadata, key) {
+	if (!metadata) return undefined;
+	const nested = metadata["dg-note-properties"];
+	if (nested && key in nested) return nested[key];
+	if (key in metadata) return metadata[key];
+	return undefined;
+}
+
+/**
+ * Get all user-visible property keys from metadata.
+ */
+function getMetaKeys(metadata) {
+	if (!metadata) return [];
+	const keys = new Set();
+	const nested = metadata["dg-note-properties"];
+	if (nested) {
+		for (const key of Object.keys(nested)) keys.add(key);
+	}
+	for (const key of Object.keys(metadata)) {
+		if (key !== "dg-note-properties") keys.add(key);
+	}
+	return Array.from(keys);
+}
+
+// URL-to-title lookup, populated by renderViews before rendering
+let urlTitleMap = {};
+
+// --- Date formatting ---
+
+const ISO_DATE_REGEX = /^\d{4}-\d{2}-\d{2}(T\d{2}:\d{2}(:\d{2})?(\.\d+)?(Z|[+-]\d{2}:\d{2})?)?$/;
+
+function isISODate(str) {
+	return ISO_DATE_REGEX.test(str);
+}
+
+// --- Helper functions ---
+
+/**
+ * Escape HTML entities in a string.
+ */
+function escapeHtml(str) {
+	if (str == null) return "";
+	return String(str)
+		.replace(/&/g, "&amp;")
+		.replace(/</g, "&lt;")
+		.replace(/>/g, "&gt;")
+		.replace(/"/g, "&quot;")
+		.replace(/'/g, "&#x27;");
+}
+
+/**
+ * Internal keys to skip during column auto-detection.
+ */
+const INTERNAL_KEY_PATTERN = /^(tags|dg-.*|__formulas)$/;
+
+/**
+ * Determine the list of columns for a view.
+ * Uses config.order if available, otherwise auto-detects from row metadata.
+ */
+function getColumns(config, rows, properties) {
+	if (config.order && Array.isArray(config.order) && config.order.length > 0) {
+		return config.order;
+	}
+
+	// Auto-detect: collect all metadata keys from rows, skip internal keys
+	const keySet = new Set();
+	keySet.add("file.name");
+	for (const row of rows) {
+		for (const key of getMetaKeys(row.metadata)) {
+			if (!INTERNAL_KEY_PATTERN.test(key)) {
+				keySet.add(key);
+			}
+		}
+	}
+	return Array.from(keySet);
+}
+
+/**
+ * Get display name for a column.
+ */
+function getDisplayName(column, properties) {
+	if (properties && properties[column] && properties[column].displayName) {
+		return properties[column].displayName;
+	}
+
+	if (column === "file.name") return "Name";
+
+	// Strip prefixes: formula.x → x, file.folder → folder
+	let name = column;
+	if (name.startsWith("formula.")) name = name.slice(8);
+	if (name.startsWith("file.")) name = name.slice(5);
+
+	// Capitalize first letter
+	return name.charAt(0).toUpperCase() + name.slice(1);
+}
+
+/**
+ * Extract the file name from a row's path.
+ */
+function getFileName(row) {
+	if (!row.path) return "";
+	const parts = row.path.split("/");
+	return parts[parts.length - 1].replace(/\.[^.]+$/, "");
+}
+
+/**
+ * Get a cell value from a row for a given column.
+ */
+function getCellValue(row, column) {
+	if (column === "file.name") {
+		return getFileName(row);
+	}
+	if (column === "file.folder") {
+		if (!row.path) return "";
+		const lastSlash = row.path.lastIndexOf("/");
+		return lastSlash === -1 ? "" : row.path.substring(0, lastSlash);
+	}
+	if (column === "file.path") {
+		return row.path || "";
+	}
+	if (column === "file.ext") {
+		if (!row.path) return "md";
+		const dotIdx = row.path.lastIndexOf(".");
+		return dotIdx === -1 ? "md" : row.path.substring(dotIdx + 1);
+	}
+	if (column === "file.links") {
+		return row._links || [];
+	}
+	if (column === "file.backlinks") {
+		return row._backlinks || [];
+	}
+	if (column === "file.tags") {
+		return (row.metadata && row.metadata.tags) || [];
+	}
+	// Handle formula.* columns
+	if (column.startsWith("formula.")) {
+		const formulaKey = column.slice(8);
+		if (row.__formulas && row.__formulas[formulaKey] !== undefined) {
+			return row.__formulas[formulaKey];
+		}
+		return undefined;
+	}
+	// Check user properties (nested + fallback), then __formulas
+	const metaVal = getMetaValue(row.metadata, column);
+	if (metaVal !== undefined) {
+		return metaVal;
+	}
+	if (row.__formulas && row.__formulas[column] !== undefined) {
+		return row.__formulas[column];
+	}
+	return undefined;
+}
+
+/**
+ * Format a cell value for display as HTML.
+ */
+function formatCellValue(value, column, row) {
+	if (column === "file.name") {
+		const name = getFileName(row);
+		const url = row.url || "";
+		return `<a href="${escapeHtml(url)}" class="internal-link">${escapeHtml(name)}</a>`;
+	}
+
+	if (value === true) {
+		return '<input type="checkbox" checked disabled />';
+	}
+	if (value === false) {
+		return '<input type="checkbox" disabled />';
+	}
+
+	if (Array.isArray(value)) {
+		return value.map((item) => {
+			if (typeof item === "string" && item.startsWith("/")) {
+				// URL path — render as clickable internal link with title
+				const title = urlTitleMap[item]
+					|| urlTitleMap[item.replace(/\/$/, "") + "/"]
+					|| null;
+				if (title) {
+					return `<a href="${escapeHtml(item)}" class="internal-link">${escapeHtml(String(title))}</a>`;
+				}
+				// Unresolved link — render as dead link
+				const slug = item.replace(/^\/|\/$/g, "").split("/").pop() || item;
+				return `<a href="/404" class="internal-link is-unresolved">${escapeHtml(decodeURIComponent(slug))}</a>`;
+			}
+			if (typeof item === "string" && !item.startsWith("/") && item.includes("/")) {
+				// Non-URL path with slashes (e.g. raw wikilink stem like "04 - PERMANENT/Note Name") — dead link
+				const slug = item.split("/").pop().replace(/\.md$/, "") || item;
+				return `<a href="/404" class="internal-link is-unresolved">${escapeHtml(slug)}</a>`;
+			}
+			return escapeHtml(String(item));
+		}).join(", ");
+	}
+
+	if (value == null) {
+		return "";
+	}
+
+	// Render ISO dates using the same pattern as the existing site —
+	// a <span class="human-date"> that Luxon formats client-side using
+	// the user's configured TIMESTAMP_FORMAT setting.
+	if (typeof value === "string" && isISODate(value)) {
+		return `<span class="human-date" data-date="${escapeHtml(value)}"></span>`;
+	}
+
+	if (value instanceof Date && !isNaN(value.getTime())) {
+		// today() and now() should be evaluated client-side, not at build time
+		if (value._basesType === "today") {
+			return '<span class="bases-dynamic-date" data-type="today"></span>';
+		}
+		if (value._basesType === "now") {
+			return '<span class="bases-dynamic-date" data-type="now"></span>';
+		}
+		return `<span class="human-date" data-date="${escapeHtml(value.toISOString())}"></span>`;
+	}
+
+	return escapeHtml(String(value));
+}
+
+/**
+ * Build a group header block for cards/list grouped views.
+ */
+function buildGroupHeader(group) {
+	return `<div class="obsidian-base-group-header-block"><span class="obsidian-base-group-label">${escapeHtml(String(group.key || "—"))}</span> <span class="obsidian-base-group-count">${group.rows.length}</span></div>`;
+}
+
+// --- View renderers ---
+
+/**
+ * Render a table view for the given rows.
+ */
+function renderTable(view, properties) {
+	const { config, rows, groups, computedSummaries } = view;
+	const columns = getColumns(config, rows, properties);
+
+	if (rows.length === 0 && (!groups || groups.length === 0)) {
+		return '<div class="obsidian-base-table-wrapper"><p class="obsidian-base-empty">No results</p></div>';
+	}
+
+	if (groups) {
+		let html = '<div class="obsidian-base-table-wrapper">';
+		html += "<table><thead><tr>";
+		for (const col of columns) {
+			html += `<th>${escapeHtml(getDisplayName(col, properties))}</th>`;
+		}
+		html += "</tr></thead><tbody>";
+		for (const group of groups) {
+			// Group header row spanning all columns
+			html += `<tr class="obsidian-base-group-row"><td colspan="${columns.length}"><span class="obsidian-base-group-label">${escapeHtml(String(group.key || "—"))}</span> <span class="obsidian-base-group-count">${group.rows.length}</span></td></tr>`;
+			for (const row of group.rows) {
+				html += "<tr>";
+				for (const col of columns) {
+					const value = getCellValue(row, col);
+					html += `<td>${formatCellValue(value, col, row)}</td>`;
+				}
+				html += "</tr>";
+			}
+		}
+		html += "</tbody></table>";
+		html += buildSummaryBar(columns, computedSummaries, config.summaries);
+		html += "</div>";
+		return html;
+	}
+
+	let html = '<div class="obsidian-base-table-wrapper">';
+	html += buildTable(columns, rows, properties);
+	html += buildSummaryBar(columns, computedSummaries, config.summaries);
+	html += "</div>";
+	return html;
+}
+
+function buildTable(columns, rows, properties) {
+	let html = "<table><thead><tr>";
+	for (const col of columns) {
+		html += `<th>${escapeHtml(getDisplayName(col, properties))}</th>`;
+	}
+	html += "</tr></thead><tbody>";
+
+	for (const row of rows) {
+		html += "<tr>";
+		for (const col of columns) {
+			const value = getCellValue(row, col);
+			html += `<td>${formatCellValue(value, col, row)}</td>`;
+		}
+		html += "</tr>";
+	}
+	html += "</tbody></table>";
+	return html;
+}
+
+/**
+ * Build a summary bar that sits outside and below the table.
+ */
+function buildSummaryBar(columns, computedSummaries, summaryConfig) {
+	if (!computedSummaries || Object.keys(computedSummaries).length === 0) {
+		return "";
+	}
+
+	let html = '<div class="obsidian-base-summary-bar">';
+	for (const col of columns) {
+		if (computedSummaries[col] !== undefined) {
+			const label = (summaryConfig && summaryConfig[col]) || "";
+			const displayName = getDisplayName(col);
+			html += `<div class="obsidian-base-summary-item"><span class="obsidian-base-summary-col">${escapeHtml(displayName)}</span> <span class="obsidian-base-summary-label">${escapeHtml(String(label))}</span> <span class="obsidian-base-summary-value">${escapeHtml(String(computedSummaries[col]))}</span></div>`;
+		}
+	}
+	html += "</div>";
+	return html;
+}
+
+/**
+ * Render a cards view.
+ */
+function renderCards(view, properties) {
+	const { config, rows, groups } = view;
+	const columns = getColumns(config, rows, properties);
+	const cardSize = config.cardSize || 200;
+	const imageFit = config.imageFit || "cover";
+	const imageAspectRatio = config.imageAspectRatio || 1.5;
+	const imageField = config.image || null;
+
+	if (rows.length === 0 && (!groups || groups.length === 0)) {
+		return '<p class="obsidian-base-empty">No results</p>';
+	}
+
+	if (groups) {
+		let html = "";
+		for (const group of groups) {
+			html += buildGroupHeader(group);
+			html += buildCardsGrid(group.rows, columns, cardSize, imageField, imageFit, imageAspectRatio, properties);
+		}
+		return html;
+	}
+
+	return buildCardsGrid(rows, columns, cardSize, imageField, imageFit, imageAspectRatio, properties);
+}
+
+function buildCardsGrid(rows, columns, cardSize, imageField, imageFit, imageAspectRatio, properties) {
+	let html = `<div class="obsidian-base-cards" style="grid-template-columns: repeat(auto-fill, minmax(${cardSize}px, 1fr));">`;
+
+	for (const row of rows) {
+		html += '<div class="obsidian-base-card">';
+
+		// Image section
+		if (imageField) {
+			let imgValue = getCellValue(row, imageField);
+			if (imgValue) {
+				imgValue = String(imgValue);
+				// Resolve vault image paths to published URLs
+				if (!imgValue.startsWith("http") && !imgValue.startsWith("/")) {
+					imgValue = "/img/user/" + imgValue;
+				}
+				html += `<div class="obsidian-base-card-image"><img src="${escapeHtml(imgValue)}" style="object-fit: ${escapeHtml(imageFit)}; aspect-ratio: ${escapeHtml(String(imageAspectRatio))};" loading="lazy" /></div>`;
+			}
+		}
+
+		// Content section
+		html += '<div class="obsidian-base-card-content">';
+		// Title
+		const name = getFileName(row);
+		const url = row.url || "";
+		html += `<div class="obsidian-base-card-title"><a href="${escapeHtml(url)}" class="internal-link">${escapeHtml(name)}</a></div>`;
+
+		// Other fields (skip file.name and image field)
+		for (const col of columns) {
+			if (col === "file.name" || col === imageField) continue;
+			const value = getCellValue(row, col);
+			if (value == null) continue;
+			const displayName = getDisplayName(col, properties);
+			html += `<div class="obsidian-base-card-field"><span class="obsidian-base-card-label">${escapeHtml(displayName)}</span>: <span class="obsidian-base-card-value">${formatCellValue(value, col, row)}</span></div>`;
+		}
+
+		html += "</div></div>";
+	}
+
+	html += "</div>";
+	return html;
+}
+
+/**
+ * Render a list view.
+ */
+function renderList(view, properties) {
+	const { config, rows, groups } = view;
+	const columns = getColumns(config, rows, properties);
+
+	if (rows.length === 0 && (!groups || groups.length === 0)) {
+		return '<p class="obsidian-base-empty">No results</p>';
+	}
+
+	if (groups) {
+		let html = "";
+		for (const group of groups) {
+			html += buildGroupHeader(group);
+			html += buildList(group.rows, columns, properties);
+		}
+		return html;
+	}
+
+	return buildList(rows, columns, properties);
+}
+
+function buildList(rows, columns, properties) {
+	let html = '<ul class="obsidian-base-list">';
+	for (const row of rows) {
+		const parts = [];
+		for (const col of columns) {
+			parts.push(formatCellValue(getCellValue(row, col), col, row));
+		}
+		html += `<li>${parts.join(" — ")}</li>`;
+	}
+	html += "</ul>";
+	return html;
+}
+
+// --- Main export ---
+
+/**
+ * SVG icon for a view type, matching Obsidian's UI.
+ */
+function viewTypeIcon(type) {
+	switch (type) {
+		case "table":
+			return '<svg class="obsidian-bases-view-icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2"/><line x1="3" y1="9" x2="21" y2="9"/><line x1="3" y1="15" x2="21" y2="15"/><line x1="9" y1="3" x2="9" y2="21"/></svg>';
+		case "cards":
+			return '<svg class="obsidian-bases-view-icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>';
+		case "list":
+			return '<svg class="obsidian-bases-view-icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="8" y1="6" x2="21" y2="6"/><line x1="8" y1="12" x2="21" y2="12"/><line x1="8" y1="18" x2="21" y2="18"/><line x1="3" y1="6" x2="3.01" y2="6"/><line x1="3" y1="12" x2="3.01" y2="12"/><line x1="3" y1="18" x2="3.01" y2="18"/></svg>';
+		default:
+			return '';
+	}
+}
+
+/**
+ * Render all views from a query result as HTML.
+ * @param {object} queryResult - Output from executeBaseQuery
+ * @returns {string} HTML string
+ */
+function renderViews(queryResult, allNotes) {
+	const { properties, views } = queryResult;
+
+	// Build URL-to-title map for resolving link display names
+	urlTitleMap = {};
+	if (allNotes) {
+		for (const note of allNotes) {
+			if (note.url) {
+				const title = (note.metadata && (note.metadata.title ||
+					(note.metadata["dg-note-properties"] && note.metadata["dg-note-properties"].title)))
+					|| note.fileSlug || note.url;
+				urlTitleMap[note.url] = title;
+			}
+		}
+	}
+
+	if (!views || views.length === 0) {
+		return '<p class="obsidian-base-empty">No views defined</p>';
+	}
+
+	const renderedPanels = views.map((view) => {
+		switch (view.config.type) {
+			case "cards":
+				return renderCards(view, properties);
+			case "list":
+				return renderList(view, properties);
+			case "table":
+			default:
+				return renderTable(view, properties);
+		}
+	});
+
+	// Single view — no dropdown, but show toolbar with name and count
+	if (views.length === 1) {
+		const view = views[0];
+		const rowCount = view.rows ? view.rows.length : 0;
+		let html = '<div class="obsidian-bases-views">';
+		html += '<div class="obsidian-bases-toolbar">';
+		html += `<span class="obsidian-bases-single-view-name">${viewTypeIcon(view.config.type)} ${escapeHtml(view.config.name)}</span>`;
+		html += `<span class="obsidian-bases-result-count">${rowCount} results</span>`;
+		html += '</div>';
+		html += renderedPanels[0];
+		html += '</div>';
+		return html;
+	}
+
+	// Multi-view with dropdown selector (matches Obsidian UI)
+	const activeView = views[0];
+	const rowCount = activeView.rows ? activeView.rows.length : 0;
+
+	let html = '<div class="obsidian-bases-views">';
+
+	// Toolbar with dropdown
+	html += '<div class="obsidian-bases-toolbar">';
+	html += '<div class="obsidian-bases-view-selector">';
+	html += `<button class="obsidian-bases-active-view" aria-expanded="false">`;
+	html += `${viewTypeIcon(activeView.config.type)} `;
+	html += `<span class="obsidian-bases-active-view-name">${escapeHtml(activeView.config.name)}</span>`;
+	html += ` <svg class="obsidian-bases-chevron" xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="6 9 12 15 18 9"></polyline></svg>`;
+	html += `</button>`;
+
+	// Dropdown menu
+	html += '<div class="obsidian-bases-dropdown" style="display:none">';
+	for (let i = 0; i < views.length; i++) {
+		const activeClass = i === 0 ? " active" : "";
+		html += `<button class="obsidian-bases-dropdown-item${activeClass}" data-view-index="${i}">`;
+		html += `${viewTypeIcon(views[i].config.type)} `;
+		html += `${escapeHtml(views[i].config.name)}`;
+		html += `</button>`;
+	}
+	html += "</div></div>";
+
+	// Result count
+	html += `<span class="obsidian-bases-result-count"><span class="obsidian-bases-count-value">${rowCount}</span> results</span>`;
+	html += "</div>";
+
+	// View panels
+	for (let i = 0; i < renderedPanels.length; i++) {
+		const hidden = i > 0 ? ' style="display:none"' : "";
+		html += `<div class="obsidian-bases-view-panel" data-view-index="${i}"${hidden}>${renderedPanels[i]}</div>`;
+	}
+
+	html += "</div>";
+	return html;
+}
+
+module.exports = {
+	renderViews,
+	// Export helpers for potential reuse
+	escapeHtml,
+	getColumns,
+	getDisplayName,
+	getCellValue,
+	formatCellValue,
+};

--- a/src/helpers/basesPlugin.js
+++ b/src/helpers/basesPlugin.js
@@ -1,0 +1,49 @@
+const { executeBaseQuery, renderViews } = require("./bases-engine");
+const linkUtils = require("./linkUtils");
+
+// Cache rendered HTML keyed by YAML + notes count to avoid stale results
+// during the data cascade build phase
+const renderCache = new Map();
+
+function basesPlugin(md) {
+  const origFence =
+    md.renderer.rules.fence ||
+    function (tokens, idx, options, env, self) {
+      return self.renderToken(tokens, idx, options);
+    };
+
+  md.renderer.rules.fence = (tokens, idx, options, env, self) => {
+    const token = tokens[idx];
+
+    if (token.info.trim() === "base") {
+      try {
+        // Prefer enriched notes with links/backlinks (from graph builder),
+        // fall back to plain notes from the data cascade
+        const notes = linkUtils._basesNotesWithLinks || (env && env.basesNotes) || [];
+        return renderBaseBlock(token.content, notes);
+      } catch (err) {
+        console.error("Error processing base query:", err);
+        return '<div class="obsidian-base-error">' + escapeHtml(err.message || "Unknown error") + '</div>';
+      }
+    }
+
+    return origFence(tokens, idx, options, env, self);
+  };
+}
+
+function renderBaseBlock(yamlContent, notes) {
+  // Cache key includes notes length so we don't serve stale results
+  // if the collection wasn't fully built on a prior call
+  const cacheKey = yamlContent + "\0" + notes.length;
+  if (renderCache.has(cacheKey)) return renderCache.get(cacheKey);
+  const result = executeBaseQuery(yamlContent, notes);
+  const html = renderViews(result, notes);
+  renderCache.set(cacheKey, html);
+  return html;
+}
+
+function escapeHtml(str) {
+  return String(str).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+}
+
+module.exports = { basesPlugin };

--- a/src/helpers/linkUtils.js
+++ b/src/helpers/linkUtils.js
@@ -4,6 +4,15 @@ const internalLinkRegex = /href="\/(.*?)"/g;
 // Format: <iframe src="/path/" class="canvas-file-iframe" ...>
 // Use non-greedy [^>]*? to avoid over-matching
 const iframeSrcRegex = /<iframe[^>]*?src="(\/[^"#]*)"[^>]*?class="canvas-file-iframe"/g;
+// Match ```base code blocks to extract links from bases queries
+const basesBlockRegex = /```base\n([\s\S]*?)```/g;
+
+let basesEngine = null;
+try {
+  basesEngine = require("./bases-engine");
+} catch (e) {
+  // bases-engine not available, skip bases link extraction
+}
 
 function extractLinks(content) {
   // Extract iframe sources for canvas embeds
@@ -42,14 +51,57 @@ function extractLinks(content) {
   ];
 }
 
+// Cache for bases query results, keyed by YAML content.
+// Built once per build, shared across all notes.
+const basesQueryCache = new Map();
+
+/**
+ * Extract outbound links from ```base code blocks by running the query
+ * against the notes collection and collecting the URLs of matched notes.
+ * Results are cached so identical queries and repeated calls are fast.
+ */
+function extractBasesLinks(content, basesNotes) {
+  if (!basesEngine) return [];
+
+  const links = [];
+  let match;
+  basesBlockRegex.lastIndex = 0;
+  while ((match = basesBlockRegex.exec(content)) !== null) {
+    const yamlContent = match[1];
+
+    if (!basesQueryCache.has(yamlContent)) {
+      try {
+        const result = basesEngine.executeBaseQuery(yamlContent, basesNotes);
+        const urls = [];
+        for (const view of result.views) {
+          for (const row of view.rows) {
+            if (row.url) urls.push(row.url);
+          }
+        }
+        basesQueryCache.set(yamlContent, urls);
+      } catch (e) {
+        basesQueryCache.set(yamlContent, []);
+      }
+    }
+
+    links.push(...basesQueryCache.get(yamlContent));
+  }
+  return links;
+}
+
 async function getGraph(data) {
   let nodes = {};
   let links = [];
   let stemURLs = {};
   let homeAlias = "/";
 
-  // Process notes sequentially to handle async reads
   const notes = data.collections.note || [];
+
+  // Clear cache from any previous build (e.g. --watch mode)
+  basesQueryCache.clear();
+
+  // --- Pass 1: Read content, extract wikilinks/internal links, build nodes ---
+  const noteContents = [];
   for (let idx = 0; idx < notes.length; idx++) {
     const v = notes[idx];
     let fpath = v.filePathStem.replace("/notes/", "");
@@ -59,9 +111,9 @@ async function getGraph(data) {
       group = parts[parts.length - 2];
     }
 
-    // Use async read() method instead of accessing frontMatter directly
     const templateContent = await v.template.read();
     const content = templateContent?.content || "";
+    noteContents.push(content);
 
     nodes[v.url] = {
       id: idx,
@@ -86,6 +138,8 @@ async function getGraph(data) {
       homeAlias = v.url;
     }
   }
+
+  // --- Pass 2: Resolve outbound links and compute backlinks ---
   Object.values(nodes).forEach((node) => {
     let outBound = new Set();
     node.outBound.forEach((olink) => {
@@ -103,11 +157,57 @@ async function getGraph(data) {
       }
     });
   });
+
+  // Convert Sets to Arrays
   Object.keys(nodes).map((k) => {
     nodes[k].neighbors = Array.from(nodes[k].neighbors);
     nodes[k].backLinks = Array.from(nodes[k].backLinks);
     nodes[k].size = nodes[k].neighbors.length;
   });
+
+  // --- Pass 3: Build basesNotes with links/backlinks, then extract bases links ---
+  // Now that we know all links and backlinks, inject them into the notes
+  // so bases queries can access file.links and file.backlinks.
+  const urlToNode = nodes;
+  const basesNotes = notes.map((item) => {
+    const url = (urlToNode[item.url] || {});
+    return {
+      path: item.filePathStem.replace("/notes/", ""),
+      url: item.url,
+      metadata: item.data,
+      fileSlug: item.fileSlug,
+      // Inject computed link data for bases queries
+      _links: url.outBound || [],
+      _backlinks: url.backLinks || [],
+    };
+  });
+
+  // Extract bases links and add them as additional outbound links
+  for (let idx = 0; idx < notes.length; idx++) {
+    const v = notes[idx];
+    const content = noteContents[idx];
+    const basesLinks = extractBasesLinks(content, basesNotes);
+    if (basesLinks.length > 0) {
+      const node = nodes[v.url];
+      for (const blink of basesLinks) {
+        if (!node.outBound.includes(blink)) {
+          node.outBound.push(blink);
+          let n = nodes[blink];
+          if (n) {
+            if (!n.backLinks.includes(v.url)) n.backLinks.push(v.url);
+            if (!n.neighbors.includes(v.url)) n.neighbors.push(v.url);
+            if (!node.neighbors.includes(blink)) node.neighbors.push(blink);
+            links.push({ source: node.id, target: n.id });
+          }
+        }
+      }
+      node.size = node.neighbors.length;
+    }
+  }
+
+  // Store enriched basesNotes for the markdown-it plugin to use
+  exports._basesNotesWithLinks = basesNotes;
+
   return {
     homeAlias,
     nodes,
@@ -119,3 +219,4 @@ exports.wikiLinkRegex = wikiLinkRegex;
 exports.internalLinkRegex = internalLinkRegex;
 exports.extractLinks = extractLinks;
 exports.getGraph = getGraph;
+exports._basesNotesWithLinks = null;

--- a/src/site/_includes/components/basesScript.njk
+++ b/src/site/_includes/components/basesScript.njk
@@ -1,0 +1,80 @@
+<script>
+document.addEventListener("DOMContentLoaded", function() {
+  document.querySelectorAll(".obsidian-bases-views").forEach(function(container) {
+    var toggle = container.querySelector(".obsidian-bases-active-view");
+    var dropdown = container.querySelector(".obsidian-bases-dropdown");
+    var items = container.querySelectorAll(".obsidian-bases-dropdown-item");
+    var panels = container.querySelectorAll(".obsidian-bases-view-panel");
+    var nameEl = container.querySelector(".obsidian-bases-active-view-name");
+    var countEl = container.querySelector(".obsidian-bases-count-value");
+
+    if (!toggle || !dropdown) return;
+
+    // Toggle dropdown on click
+    toggle.addEventListener("click", function(e) {
+      e.stopPropagation();
+      var open = dropdown.style.display !== "none";
+      dropdown.style.display = open ? "none" : "block";
+      toggle.setAttribute("aria-expanded", !open);
+    });
+
+    // Close dropdown on outside click
+    document.addEventListener("click", function() {
+      dropdown.style.display = "none";
+      toggle.setAttribute("aria-expanded", "false");
+    });
+
+    // Switch view on item click
+    items.forEach(function(item) {
+      item.addEventListener("click", function(e) {
+        e.stopPropagation();
+        var idx = this.getAttribute("data-view-index");
+
+        // Update active states
+        items.forEach(function(el) { el.classList.remove("active"); });
+        this.classList.add("active");
+
+        // Switch panels
+        panels.forEach(function(p) { p.style.display = "none"; });
+        var target = container.querySelector('.obsidian-bases-view-panel[data-view-index="' + idx + '"]');
+        if (target) target.style.display = "block";
+
+        // Update toolbar button text and icon
+        var icon = this.querySelector(".obsidian-bases-view-icon");
+        var activeIcon = toggle.querySelector(".obsidian-bases-view-icon");
+        if (icon && activeIcon) activeIcon.replaceWith(icon.cloneNode(true));
+        if (nameEl) nameEl.textContent = this.textContent.trim();
+
+        // Update result count
+        if (countEl && target) {
+          var rows = target.querySelectorAll("tbody tr, .obsidian-base-card, .obsidian-base-list li");
+          countEl.textContent = rows.length;
+        }
+
+        // Close dropdown
+        dropdown.style.display = "none";
+        toggle.setAttribute("aria-expanded", "false");
+      });
+    });
+  });
+
+  // Fill in dynamic date placeholders (today/now)
+  document.querySelectorAll(".bases-dynamic-date").forEach(function(el) {
+    var type = el.getAttribute("data-type");
+    var now = new Date();
+    if (type === "today") {
+      var y = now.getFullYear();
+      var m = String(now.getMonth() + 1).padStart(2, "0");
+      var d = String(now.getDate()).padStart(2, "0");
+      el.textContent = y + "-" + m + "-" + d;
+    } else if (type === "now") {
+      var y = now.getFullYear();
+      var m = String(now.getMonth() + 1).padStart(2, "0");
+      var d = String(now.getDate()).padStart(2, "0");
+      var h = String(now.getHours()).padStart(2, "0");
+      var min = String(now.getMinutes()).padStart(2, "0");
+      el.textContent = y + "-" + m + "-" + d + " " + h + ":" + min;
+    }
+  });
+});
+</script>

--- a/src/site/_includes/layouts/index.njk
+++ b/src/site/_includes/layouts/index.njk
@@ -75,5 +75,6 @@
       {% include imp %}
     {% endfor %}
     {%include "components/lucideIcons.njk"%}
+    {%include "components/basesScript.njk"%}
     </body>
   </html>

--- a/src/site/_includes/layouts/note.njk
+++ b/src/site/_includes/layouts/note.njk
@@ -95,5 +95,6 @@ permalink: "notes/{{ page.fileSlug | slugify }}/"
     {% if contentClasses and "canvas-page" in contentClasses %}
       {%include "components/canvasScript.njk"%}
     {% endif %}
+    {% include "components/basesScript.njk" %}
   </body>
 </html>

--- a/src/site/notes/notes.11tydata.js
+++ b/src/site/notes/notes.11tydata.js
@@ -17,6 +17,15 @@ module.exports = {
       }
       return data.permalink || undefined;
     },
+    basesNotes: (data) => {
+      if (!data.collections || !data.collections.note) return [];
+      return data.collections.note.map((item) => ({
+        path: item.filePathStem.replace("/notes/", ""),
+        url: item.url,
+        metadata: item.data,
+        fileSlug: item.fileSlug,
+      }));
+    },
     settings: (data) => {
       const noteSettings = {};
       allSettings.forEach((setting) => {

--- a/src/site/styles/obsidian-bases.scss
+++ b/src/site/styles/obsidian-bases.scss
@@ -1,0 +1,264 @@
+.obsidian-base-table-wrapper {
+  overflow-x: auto;
+  margin: 1em 0;
+}
+
+.obsidian-base-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9em;
+
+  th, td {
+    padding: 0.5em 0.75em;
+    border: 1px solid var(--background-modifier-border, #ddd);
+    text-align: left;
+    vertical-align: top;
+  }
+
+  th {
+    background: var(--background-secondary, #f5f5f5);
+    font-weight: 600;
+    white-space: nowrap;
+  }
+
+  tbody tr:hover {
+    background: var(--background-modifier-hover, rgba(0,0,0,0.04));
+  }
+
+  .obsidian-base-group-row td {
+    background: var(--background-secondary, #f5f5f5);
+    font-weight: 600;
+    padding: 0.4em 0.75em;
+    border-bottom: 1px solid var(--background-modifier-border, #ddd);
+  }
+
+  .obsidian-base-group-label {
+    color: var(--text-normal, #333);
+  }
+
+  .obsidian-base-group-count {
+    color: var(--text-muted, #888);
+    font-weight: 400;
+    font-size: 0.85em;
+
+    &::before { content: "("; }
+    &::after { content: ")"; }
+  }
+}
+
+.obsidian-base-group-header-block {
+  padding: 0.5em 0.2em;
+  margin-top: 0.75em;
+  font-weight: 600;
+  border-bottom: 1px solid var(--background-modifier-border, #ddd);
+}
+
+.obsidian-base-summary-bar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1em;
+  padding: 0.5em 0.75em;
+  margin-top: 0.25em;
+  font-size: 0.85em;
+  color: var(--text-muted, #888);
+  border-top: 1px solid var(--background-modifier-border, #ddd);
+}
+
+.obsidian-base-summary-item {
+  display: inline-flex;
+  gap: 0.3em;
+}
+
+.obsidian-base-summary-col {
+  font-weight: 500;
+  color: var(--text-normal, #333);
+}
+
+.obsidian-base-summary-label {
+  color: var(--text-muted, #888);
+}
+
+.obsidian-base-summary-value {
+  font-weight: 600;
+  color: var(--text-normal, #333);
+}
+
+.obsidian-base-cards {
+  display: grid;
+  gap: 1em;
+  margin: 1em 0;
+}
+
+.obsidian-base-card {
+  border: 1px solid var(--background-modifier-border, #ddd);
+  border-radius: 8px;
+  overflow: hidden;
+  background: var(--background-primary, #fff);
+  transition: box-shadow 0.2s;
+
+  &:hover { box-shadow: 0 2px 8px rgba(0,0,0,0.1); }
+}
+
+.obsidian-base-card-image {
+  overflow: hidden;
+  img { width: 100%; height: 100%; display: block; }
+}
+
+.obsidian-base-card-content { padding: 0.75em; }
+.obsidian-base-card-title { font-weight: 600; margin-bottom: 0.5em; a { text-decoration: none; } }
+.obsidian-base-card-field { font-size: 0.85em; color: var(--text-muted, #888); margin-bottom: 0.25em; }
+.obsidian-base-card-label { font-weight: 500; color: var(--text-normal, #333); }
+
+.obsidian-base-list {
+  list-style: disc;
+  padding-left: 1.5em;
+  margin: 1em 0;
+  li { padding: 0.25em 0; }
+}
+
+.obsidian-bases-views {
+  margin: 1em 0;
+}
+
+// Toolbar with dropdown selector and result count
+.obsidian-bases-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 0.75em;
+  padding: 0.4em 0;
+  margin-bottom: 0.25em;
+  border-bottom: 1px solid var(--background-modifier-border, #ddd);
+  text-align: left;
+}
+
+.obsidian-bases-view-selector {
+  position: relative;
+}
+
+button.obsidian-bases-active-view.obsidian-bases-active-view {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35em;
+  padding: 0.25em 0.5em;
+  border: none;
+  outline: none;
+  background-color: transparent;
+  cursor: pointer;
+  font-size: 0.95em;
+  font-weight: 600;
+  color: var(--text-normal, #333);
+  border-radius: 4px;
+  transition: background-color 0.15s;
+  -webkit-appearance: none;
+  appearance: none;
+  box-shadow: none;
+  font-family: inherit;
+
+  &:hover {
+    background-color: var(--background-modifier-hover, rgba(0,0,0,0.04));
+  }
+
+  &:focus {
+    outline: none;
+    box-shadow: none;
+  }
+}
+
+.obsidian-bases-chevron {
+  opacity: 0.5;
+}
+
+.obsidian-bases-view-icon {
+  vertical-align: middle;
+  opacity: 0.7;
+}
+
+.obsidian-bases-single-view-name {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35em;
+  font-size: 0.95em;
+  font-weight: 600;
+  color: var(--text-normal, #333);
+}
+
+.obsidian-bases-result-count {
+  font-size: 0.85em;
+  color: var(--text-muted, #888);
+}
+
+// Dropdown menu
+.obsidian-bases-dropdown {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  z-index: 100;
+  min-width: 180px;
+  padding: 0.35em;
+  background: var(--background-primary, #fff);
+  border: 1px solid var(--background-modifier-border, #ddd);
+  border-radius: 8px;
+  box-shadow: 0 4px 16px rgba(0,0,0,0.15);
+  text-align: left;
+}
+
+button.obsidian-bases-dropdown-item.obsidian-bases-dropdown-item {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 0.5em;
+  width: 100%;
+  padding: 0.45em 0.65em;
+  border: none;
+  outline: none;
+  background-color: transparent;
+  cursor: pointer;
+  font-size: 0.9em;
+  color: var(--text-normal, #333);
+  border-radius: 4px;
+  text-align: left;
+  transition: background-color 0.1s;
+  -webkit-appearance: none;
+  appearance: none;
+  box-shadow: none;
+  font-family: inherit;
+
+  &:hover {
+    background-color: var(--background-modifier-hover, rgba(0,0,0,0.06));
+  }
+
+  &:focus {
+    outline: none;
+    box-shadow: none;
+  }
+
+  &.active {
+    color: var(--text-accent, #7c3aed);
+    font-weight: 500;
+  }
+}
+
+.obsidian-base-group-header {
+  margin: 1em 0 0.5em;
+  padding-bottom: 0.25em;
+  border-bottom: 1px solid var(--background-modifier-border, #ddd);
+  font-size: 1.1em;
+}
+
+.obsidian-base-error {
+  padding: 1em;
+  margin: 1em 0;
+  border: 1px solid #e74c3c;
+  border-radius: 4px;
+  background: rgba(231,76,60,0.1);
+  color: #e74c3c;
+  font-size: 0.9em;
+}
+
+.obsidian-base-empty {
+  padding: 2em;
+  text-align: center;
+  color: var(--text-muted, #888);
+  font-style: italic;
+}

--- a/src/site/styles/style.scss
+++ b/src/site/styles/style.scss
@@ -210,3 +210,5 @@ p > code {
 .callout.is-collapsed .callout-fold .svg-icon {
     transform: rotate(-90deg);
 }
+
+@import "obsidian-bases";


### PR DESCRIPTION
Add support for rendering Obsidian Bases (structured data queries over note properties) in published digital gardens.

Standalone bases engine module (src/helpers/bases-engine/):
- Expression parser wrapping jsep for filter/formula expressions
- Expression evaluator supporting Obsidian's function set: file.* properties, hasTag/inFolder/hasProperty/hasLink filters, string/ number/list/date methods, global functions (today, now, date, if, min, max, etc.)
- Query engine with recursive filter logic (and/or/not), formula computation with AST caching, multi-key sorting, groupBy with direction, limit, and 16 built-in summary functions
- HTML view renderers for table, cards (with images), and list views
- 203 unit tests via vitest

11ty integration:
- markdown-it plugin intercepting ```base fenced code blocks
- Render caching for identical queries
- Notes data passed via env from 11ty data cascade
- Graph builder extracts bases links for backlink support
- file.links and file.backlinks computed from the graph and available in bases queries
- Obsidian-style dropdown view selector with type icons and result count
- Client-side date formatting using configured TIMESTAMP_FORMAT
- today()/now() rendered client-side (viewer's date, not build date)
- SCSS styles using Obsidian CSS variables for theme compatibility
- System tags (note, gardenEntry) filtered from file.tags

User properties:
- All frontmatter nested under dg-note-properties to avoid clashing with 11ty reserved keys (date, layout, etc.)
- Bases engine checks nested properties first, falls back to top-level
- Vault image paths in properties resolved to /img/user/ URLs