### PR TITLE
bugfix: Enhance searchableTags filter to ignore unreadl

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -351,7 +351,22 @@ module.exports = function(eleventyConfig) {
 
   eleventyConfig.addFilter("searchableTags", function(str) {
     let tags;
-    let match = str && str.match(tagRegex);
+    const searchableContent = str
+      ? (() => {
+        // Ignore HTML comments so commented-out tags are never indexed.
+        const withoutComments = str.replace(/<!--[\s\S]*?-->/g, " ");
+        const parsed = parse(withoutComments);
+
+        // Ignore content that is not part of normal readable note text.
+        // This keeps behavior closer to Obsidian tag semantics.
+        parsed.querySelectorAll("pre, code, a, script, style, noscript").forEach((node) => {
+          node.remove();
+        });
+
+        return parsed.text;
+      })()
+      : str;
+    let match = searchableContent && searchableContent.match(tagRegex);
     if (match) {
       tags = match
         .map((m) => {


### PR DESCRIPTION
This PR makes a small improvement to searchable tag extraction by ignoring tags inside HTML comments and non-readable elements (pre, code, a, script, style, noscript). To fix #335, #315 which I also encountered.

How:

Filter out unnecessary content before extract tags from file.

Result:

Visible body-text tags are still indexed as before.
Comment/markup-only tags are no longer included in search tags.

I have tested with given test case:

1. Positive case: body text tag should be indexed (#visibleBodyTag)
2. Negative cases: tags inside HTML comment / inline code / code block / anchor / script / style / noscript should not be indexed

````md
  ---
  title: Acceptance Searchable Tags
  ---
  
  #visibleBodyTag
  
  <!-- #commentedTag -->
  
  `#inlineCodeTag`
  
  ```js
  const demo = "#codeBlockTag";
  ```
  
  <a href="/">#linkAnchorTag</a>
  
  <script>#scriptTag</script>
  <style>.x::before{content:"#styleTag"}</style>
  <noscript>#noscriptTag</noscript>
````