### PR TITLE
Rewrite graph to use pixi

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,12 +81,17 @@ You can override the base Obsidian theme color variables directly:
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `--dg-graph-width` | `250px` | Graph component width |
-| `--dg-graph-height` | `250px` | Graph component height |
+| `--dg-graph-width` | `250px` | Local graph width |
+| `--dg-graph-height` | `250px` | Local graph height |
 | `--dg-graph-border-radius` | `10px` | Graph border radius |
 | `--dg-graph-margin-bottom` | `20px` | Graph bottom margin |
-| `--dg-graph-fullscreen-width` | `600px` | Fullscreen graph width |
-| `--dg-graph-fullscreen-height` | `600px` | Fullscreen graph height |
+| `--dg-graph-fullscreen-width` | `90vw` | Expanded/global graph width |
+| `--dg-graph-fullscreen-height` | `85vh` | Expanded/global graph height |
+| `--dg-graph-node-color` | `var(--text-accent)` | Active/current node color |
+| `--dg-graph-node-color-muted` | `var(--text-faint)` | Neighbor node color |
+| `--dg-graph-label-color` | `var(--text-normal)` | Node label text color |
+| `--dg-graph-bg` | `var(--background-primary)` | Graph background color |
+| `--dg-graph-border-color` | `var(--background-secondary)` | Graph border color |
 
 #### Filetree (Left Sidebar) Variables
 
@@ -183,8 +188,6 @@ You can override the base Obsidian theme color variables directly:
 | `--dg-graph-ctrl-size` | `0.7rem` | Graph controls font size |
 | `--dg-graph-ctrl-icon-size` | `14px` | Graph control icon size |
 | `--dg-graph-ctrl-gap` | `10px` | Graph controls gap |
-| `--dg-depth-slider-width` | `50px` | Depth slider width |
-| `--dg-depth-display-size` | `1.1rem` | Depth display size |
 
 #### Timestamps Variables
 

--- a/src/site/_includes/components/graphScript.njk
+++ b/src/site/_includes/components/graphScript.njk
@@ -1,243 +1,499 @@
-<script>
-    async function fetchGraphData() {
-        const graphData = await fetch('/graph.json').then(res => res.json());
-        const fullGraphData  = filterFullGraphData(graphData);
-        return {graphData, fullGraphData}
+<script type="module">
+import { forceSimulation, forceManyBody, forceCenter, forceLink, forceCollide, forceRadial } from 'd3-force';
+import { select } from 'd3-selection';
+import { zoom as d3Zoom, zoomIdentity } from 'd3-zoom';
+import { drag as d3Drag } from 'd3-drag';
+
+// Pixi v7 loaded as UMD global
+const { Application, Container, Graphics, Text, Circle } = PIXI;
+
+async function fetchGraphData() {
+    const graphData = await fetch('/graph.json').then(res => res.json());
+    const fullGraphData = filterFullGraphData(graphData);
+    return { graphData, fullGraphData };
+}
+
+function filterFullGraphData(graphData) {
+    if (!graphData) return null;
+    graphData = JSON.parse(JSON.stringify(graphData));
+    const hiddens = Object.values(graphData.nodes).filter(n => n.hide).map(n => n.id);
+    return {
+        links: graphData.links.filter(l => hiddens.indexOf(l.source) === -1 && hiddens.indexOf(l.target) === -1),
+        nodes: Object.values(graphData.nodes).filter(n => !n.hide),
+    };
+}
+
+function filterLocalGraphData(graphData) {
+    if (!graphData) return null;
+    const allNodes = JSON.parse(JSON.stringify(graphData.nodes));
+    const allLinks = JSON.parse(JSON.stringify(graphData.links));
+    let currentLink = decodeURI(window.location.pathname);
+
+    let currentNode = allNodes[currentLink];
+    if (!currentNode) {
+        const lower = currentLink.toLowerCase();
+        currentNode = Object.values(allNodes).find(v => v.url.toLowerCase() === lower);
+    }
+    if (!currentNode) {
+        currentNode = Object.values(allNodes).find(v => v.home);
+    }
+    if (!currentNode) return null;
+
+    currentNode.current = true;
+
+    // Depth 1: collect immediate neighbors (neighbors array contains URLs)
+    const neighbourhood = new Set();
+    neighbourhood.add(currentNode.url);
+    if (currentNode.neighbors) {
+        currentNode.neighbors.forEach(n => neighbourhood.add(n));
     }
 
-    function getNextLevelNeighbours(existing, remaining) {
-        const keys = Object.values(existing).map((n) => n.neighbors).flat();
-        const n_remaining = Object.keys(remaining).reduce((acc, key) => {
-                if (keys.indexOf(key) != -1) {
-                    if (!remaining[key].hide) {
-                        existing[key] = remaining[key];
-                    }
-                } else {
-                    acc[key] = remaining[key];
-                }
-                return acc;
-            }, {});
-        return existing, n_remaining;
-    }
+    const nodes = Object.values(allNodes).filter(n => {
+        if (n.hide) return false;
+        return neighbourhood.has(n.url);
+    });
 
-    function filterLocalGraphData(graphData, depth) {
-        if (graphData == null) {
-            return null;
-        }
-        let remaining = JSON.parse(JSON.stringify(graphData.nodes));
-        let links = JSON.parse(JSON.stringify(graphData.links));
-        let currentLink = decodeURI(window.location.pathname);
-        // Try exact match first, then case-insensitive match for hosting platforms
-        // that normalize URLs to lowercase (e.g., Netlify)
-        let currentNode = remaining[currentLink];
-        if (!currentNode) {
-            const lowerCurrentLink = currentLink.toLowerCase();
-            currentNode = Object.values(remaining).find((v) => v.url.toLowerCase() === lowerCurrentLink);
-        }
-        if (!currentNode) {
-            currentNode = Object.values(remaining).find((v) => v.home);
-        }
-        if (!currentNode) {
-            return null;
-        }
-        delete remaining[currentNode.url];
-        if (!currentNode.home) {
-            let home = Object.values(remaining).find((v) => v.home);
-            delete remaining[home.url];
-        }
-        currentNode.current = true;
-        let existing = {};
-        existing[currentNode.url] = currentNode;
-        for (let i = 0; i < depth; i++) {
-            existing, remaining = getNextLevelNeighbours(existing, remaining);
-        }
-        nodes = Object.values(existing);
-        if (!currentNode.home) {
-            nodes = nodes.filter(n => !n.home);
-        }
-        let ids = nodes.map((n) => n.id);
-        return {
-            nodes,
-            links: links.filter(function (con) {
-                return ids.indexOf(con.target) > -1 && ids.indexOf(con.source) > -1;
-            }),
+    // If current node is not home, exclude the home node unless it's a neighbor
+    if (!currentNode.home && currentNode.neighbors) {
+        const homeNode = nodes.find(n => n.home);
+        if (homeNode && !currentNode.neighbors.includes(homeNode.url)) {
+            const idx = nodes.indexOf(homeNode);
+            if (idx > -1) nodes.splice(idx, 1);
         }
     }
 
-    function getCssVar(variable) {return getComputedStyle(document.body).getPropertyValue(variable)}
+    const ids = nodes.map(n => n.id);
+    return {
+        nodes,
+        links: allLinks.filter(l => ids.indexOf(l.target) > -1 && ids.indexOf(l.source) > -1),
+    };
+}
 
-    function htmlDecode(input) {
-        var doc = new DOMParser().parseFromString(input, "text/html");
-        return doc.documentElement.textContent;
+function getCssVar(variable) {
+    return getComputedStyle(document.body).getPropertyValue(variable).trim();
+}
+
+// Resolve CSS color (which may contain calc/hsl) to a hex number Pixi can use
+const _colorProbe = document.createElement('div');
+_colorProbe.style.display = 'none';
+document.body.appendChild(_colorProbe);
+function resolveColor(cssValue) {
+    _colorProbe.style.color = cssValue;
+    const resolved = getComputedStyle(_colorProbe).color;
+    const match = resolved.match(/(\d+),\s*(\d+),\s*(\d+)/);
+    if (match) {
+        return (parseInt(match[1]) << 16) + (parseInt(match[2]) << 8) + parseInt(match[3]);
     }
+    return 0x666666;
+}
 
-    function renderGraph(graphData, id, delay, fullScreen) {
-        if (graphData == null) {
-            return;
-        }
-        const el = document.getElementById(id);
-        if (!el) {
-            return;
-        }
-        if (typeof ForceGraph === 'undefined') {
-            return;
-        }
-        width = el.offsetWidth;
-        height = el.offsetHeight;
-        if (width === 0 || height === 0) {
-            return;
-        }
-        try {
-        const highlightNodes = new Set();
-        let hoverNode = null;
-        const color = getCssVar("--graph-main");
-        const mutedColor = getCssVar("--graph-muted");
-        let Graph = ForceGraph()
-        (el)
-            .graphData(graphData)
-            .nodeId('id')
-            .nodeLabel('title')
-            .linkSource('source')
-            .linkTarget('target')
-            .d3AlphaDecay(0.10)
-            .width(width)
-            .height(height)
-            .linkDirectionalArrowLength(2)
-            .linkDirectionalArrowRelPos(0.5)
-            .autoPauseRedraw(false)
-            .linkColor((link) => {
-                if (hoverNode == null) {
-                    return color;
-                }
-                if (link.source.id == hoverNode.id || link.target.id == hoverNode.id) {
-                    return color;
-                } else {
-                    return mutedColor;
-                }
-                
-            })
-            .nodeCanvasObject((node, ctx) => {
-                const numberOfNeighbours = (node.neighbors && node.neighbors.length) || 2;
-                const nodeR = Math.min(7, Math.max(numberOfNeighbours / 2, 2));
-                
-                ctx.beginPath();
-                ctx.arc(node.x, node.y, nodeR, 0, 2 * Math.PI, false);
-                if (hoverNode == null) {
-                    ctx.fillStyle = color;
-                } else {
-                    if (node == hoverNode || highlightNodes.has(node.url)) {
-                        ctx.fillStyle = color;
-                    } else {
-                        ctx.fillStyle = mutedColor;
-                    }
-                }
-                 
-                ctx.fill();
-                
-                if (node.current) {
-                    ctx.beginPath();
-                    ctx.arc(node.x, node.y, nodeR + 1, 0, 2 * Math.PI, false);
-                    ctx.lineWidth = 0.5;
-                    ctx.strokeStyle = color;
-                    ctx.stroke();
-                }
+// Lightweight HTML entity decoder
+const _decodeEl = document.createElement('textarea');
+function htmlDecode(input) {
+    _decodeEl.innerHTML = input;
+    return _decodeEl.value;
+}
 
-                const label = htmlDecode(node.title)
-                const fontSize = 3.5;
-                ctx.font = `${fontSize}px Sans-Serif`;
+// Pre-compute degree map for node sizing
+function buildDegreeMap(links) {
+    const degrees = {};
+    for (const l of links) {
+        const sid = typeof l.source === 'object' ? l.source.id : l.source;
+        const tid = typeof l.target === 'object' ? l.target.id : l.target;
+        degrees[sid] = (degrees[sid] || 0) + 1;
+        degrees[tid] = (degrees[tid] || 0) + 1;
+    }
+    return degrees;
+}
 
-                ctx.textAlign = 'center';
-                ctx.textBaseline = 'top';
-                ctx.fillText(label, node.x, node.y + nodeR + 2);
-            })
-            .onNodeClick(node => {
-                window.location = node.url;
-            })
-            .onNodeHover(node => {
-                highlightNodes.clear();
-                if (node) {
-                highlightNodes.add(node);
-                node.neighbors.forEach(neighbor => highlightNodes.add(neighbor));
+function nodeRadius(nodeId, degreeMap) {
+    return 2 + Math.sqrt(degreeMap[nodeId] || 0);
+}
+
+function renderGraph(graphData, containerId, isFullScreen) {
+    if (!graphData || !graphData.nodes || graphData.nodes.length === 0) return null;
+
+    const el = document.getElementById(containerId);
+    if (!el) return null;
+
+    while (el.firstChild) el.removeChild(el.firstChild);
+
+    const width = el.offsetWidth;
+    const height = el.offsetHeight || 250;
+    if (width === 0) return null;
+
+    const color = resolveColor(getCssVar('--dg-graph-node-color') || getCssVar('--graph-main') || '#666');
+    const mutedColor = resolveColor(getCssVar('--dg-graph-node-color-muted') || getCssVar('--graph-muted') || '#ccc');
+    const textColor = resolveColor(getCssVar('--dg-graph-label-color') || getCssVar('--text-normal') || '#eee');
+    const bodyFont = getComputedStyle(document.body).fontFamily || 'Sans-Serif';
+
+    const degreeMap = buildDegreeMap(graphData.links);
+
+    const nodes = graphData.nodes.map(n => ({
+        ...n,
+        text: htmlDecode(n.title),
+    }));
+    const links = graphData.links.map(l => ({ source: l.source, target: l.target }));
+
+    // D3 Force Simulation — stronger repel for full graph to spread nodes
+    const chargeStrength = isFullScreen ? -300 : -100;
+    const linkDist = isFullScreen ? 80 : 40;
+    const radius = Math.min(width, height) / 3;
+    const simulation = forceSimulation(nodes)
+        .force('charge', forceManyBody().strength(chargeStrength))
+        .force('center', forceCenter(width / 2, height / 2).strength(0.5))
+        .force('link', forceLink(links).id(d => d.id).distance(linkDist))
+        .force('collide', forceCollide(d => nodeRadius(d.id, degreeMap) + 1).iterations(3))
+        .force('radial', forceRadial(radius, width / 2, height / 2).strength(0.05));
+
+    // Pixi v7 Application (synchronous constructor)
+    const app = new Application({
+        width,
+        height,
+        antialias: true,
+        autoStart: false,
+        autoDensity: true,
+        backgroundAlpha: 0,
+        resolution: window.devicePixelRatio,
+    });
+    el.appendChild(app.view);
+
+    const stage = app.stage;
+    stage.interactive = true;
+    stage.hitArea = app.screen;
+
+    const linkGfx = new Graphics();
+    const nodesContainer = new Container();
+    const labelsContainer = new Container();
+    stage.addChild(linkGfx, nodesContainer, labelsContainer);
+
+    let hoveredNodeId = null;
+    let hoveredNeighbours = new Set();
+    let dragging = false;
+    let dragStartTime = 0;
+    let dragStartPos = null;
+    let currentTransform = zoomIdentity;
+
+    const nodeRenderData = [];
+    const linkRenderData = [];
+
+    function updateHoverInfo(newId) {
+        hoveredNodeId = newId;
+        hoveredNeighbours.clear();
+
+        if (newId === null) {
+            for (const n of nodeRenderData) n.active = false;
+            for (const l of linkRenderData) l.active = false;
+        } else {
+            for (const l of linkRenderData) {
+                const src = l.simulationData.source;
+                const tgt = l.simulationData.target;
+                const srcId = typeof src === 'object' ? src.id : src;
+                const tgtId = typeof tgt === 'object' ? tgt.id : tgt;
+                if (srcId === newId || tgtId === newId) {
+                    hoveredNeighbours.add(srcId);
+                    hoveredNeighbours.add(tgtId);
                 }
-                hoverNode = node || null;
-                
-            });
-            if (fullScreen || (delay != null && graphData.nodes.length > 4)) {
-                setTimeout(() => {
-                    Graph.zoomToFit(5, 75);
-                }, delay || 200);
+                l.active = srcId === newId || tgtId === newId;
             }
-        return Graph;
-        } catch (e) {
-            console.warn('Graph rendering failed:', e);
-            return;
+            for (const n of nodeRenderData) {
+                n.active = hoveredNeighbours.has(n.simulationData.id);
+            }
         }
     }
 
-    function renderLocalGraph(graphData, depth, fullScreen) {
-        if (graphData == null) {
-            return;
+    // Create node graphics
+    for (const n of nodes) {
+        const r = nodeRadius(n.id, degreeMap);
+
+        const label = new Text(n.text, {
+            fontSize: 16,
+            fill: textColor,
+            fontFamily: bodyFont,
+        });
+        label.resolution = 2;
+        label.anchor.set(0.5, 1);
+        label.scale.set(1 / 3);
+        label.alpha = 0;
+
+        const gfx = new Graphics();
+        gfx.interactive = true;
+        gfx.cursor = 'pointer';
+        gfx.hitArea = new Circle(0, 0, r + 2);
+        gfx._nodeId = n.id;
+
+        // Draw node circle — current node gets main color, others get muted
+        const nodeColor = n.current ? color : mutedColor;
+        gfx.beginFill(nodeColor);
+        gfx.drawCircle(0, 0, r);
+        gfx.endFill();
+
+        if (n.current) {
+            gfx.lineStyle(0.5, color);
+            gfx.drawCircle(0, 0, r + 1.5);
         }
-        if (window.graph){
-            window.graph._destructor();
-        }
-        const data = filterLocalGraphData(graphData, depth);
-        return renderGraph(data, 'link-graph', null, fullScreen);
+
+        let oldLabelAlpha = 0;
+        gfx.on('pointerover', () => {
+            updateHoverInfo(gfx._nodeId);
+            oldLabelAlpha = label.alpha;
+            if (!dragging) updateVisuals();
+        });
+        gfx.on('pointerleave', () => {
+            updateHoverInfo(null);
+            label.alpha = oldLabelAlpha;
+            if (!dragging) updateVisuals();
+        });
+
+        nodesContainer.addChild(gfx);
+        labelsContainer.addChild(label);
+
+        nodeRenderData.push({
+            simulationData: n,
+            gfx,
+            label,
+            radius: r,
+            active: false,
+            baseAlpha: 1,
+            targetAlpha: 1,
+            currentAlpha: 1,
+        });
     }
 
-    function filterFullGraphData(graphData) {
-        if (graphData == null) {
-            return null;
-        }
-        graphData = JSON.parse(JSON.stringify(graphData));
-        const hiddens = Object.values(graphData.nodes).filter((n) => n.hide).map((n) => n.id);
-        const data = {
-            links: JSON.parse(JSON.stringify(graphData.links)).filter((l) => hiddens.indexOf(l.source) == -1 && hiddens.indexOf(l.target) == -1),
-            nodes: [...Object.values(graphData.nodes).filter((n) => !n.hide)]
-        }
-        return data
+    for (const l of links) {
+        linkRenderData.push({
+            simulationData: l,
+            active: false,
+            baseAlpha: 0.4,
+            targetAlpha: 0.4,
+            currentAlpha: 0.4,
+        });
     }
 
-    function openFullGraph(fullGraphData) {
-        lucide.createIcons({
-                attrs: {
-                    class: ["svg-icon"]
+    function updateVisuals() {
+        for (const n of nodeRenderData) {
+            n.targetAlpha = hoveredNodeId !== null ? (n.active ? 1 : 0.1) : n.baseAlpha;
+        }
+        for (const l of linkRenderData) {
+            l.targetAlpha = hoveredNodeId !== null ? (l.active ? 0.8 : 0.05) : l.baseAlpha;
+        }
+    }
+
+    function lerp(a, b, t) {
+        return a + (b - a) * t;
+    }
+
+    // D3 Drag
+    select(app.view).call(
+        d3Drag()
+            .container(() => app.view)
+            .subject(() => {
+                if (!hoveredNodeId) return null;
+                const node = nodes.find(n => n.id === hoveredNodeId);
+                if (!node) return null;
+                return {
+                    x: node.x * currentTransform.k + currentTransform.x,
+                    y: node.y * currentTransform.k + currentTransform.y,
+                    node,
+                };
+            })
+            .on('start', function (event) {
+                if (!event.active) simulation.alphaTarget(1).restart();
+                const node = event.subject.node;
+                node.fx = node.x;
+                node.fy = node.y;
+                dragStartTime = Date.now();
+                dragStartPos = { x: event.x, y: event.y };
+                dragging = true;
+            })
+            .on('drag', function (event) {
+                const node = event.subject.node;
+                node.fx = (event.x - currentTransform.x) / currentTransform.k;
+                node.fy = (event.y - currentTransform.y) / currentTransform.k;
+            })
+            .on('end', function (event) {
+                if (!event.active) simulation.alphaTarget(0);
+                const node = event.subject.node;
+                node.fx = null;
+                node.fy = null;
+                dragging = false;
+
+                const dt = Date.now() - dragStartTime;
+                const dx = event.x - dragStartPos.x;
+                const dy = event.y - dragStartPos.y;
+                const dist = Math.sqrt(dx * dx + dy * dy);
+                if (dt < 500 && dist < 5) {
+                    if (node.url) {
+                        window.location = node.url;
+                    }
                 }
-            });
-        return renderGraph(fullGraphData, "full-graph-container", 200, false);;
+            })
+    );
+
+    // D3 Zoom
+    const zoomBehavior = d3Zoom()
+        .extent([[0, 0], [width, height]])
+        .scaleExtent([0.25, 4])
+        .on('zoom', ({ transform }) => {
+            currentTransform = transform;
+            stage.scale.set(transform.k, transform.k);
+            stage.position.set(transform.x, transform.y);
+
+            const scaleOpacity = Math.max((transform.k - 1) / 3.75, 0);
+            for (const n of nodeRenderData) {
+                if (n.simulationData.id !== hoveredNodeId) {
+                    n.label.alpha = scaleOpacity;
+                }
+            }
+        });
+    select(app.view).call(zoomBehavior);
+
+    // Animation loop
+    let stopAnimation = false;
+    const smoothing = 0.15;
+
+    function animate() {
+        if (stopAnimation) return;
+
+        for (const n of nodeRenderData) {
+            const { x, y } = n.simulationData;
+            if (x == null || y == null) continue;
+            n.gfx.position.set(x, y);
+            n.label.position.set(x, y - n.radius - 2);
+
+            n.currentAlpha = lerp(n.currentAlpha, n.targetAlpha, smoothing);
+            n.gfx.alpha = n.currentAlpha;
+
+            if (n.simulationData.id === hoveredNodeId) {
+                n.label.alpha = 1;
+            }
+        }
+
+        // Draw all links in a single Graphics pass
+        linkGfx.clear();
+        for (const l of linkRenderData) {
+            const src = l.simulationData.source;
+            const tgt = l.simulationData.target;
+            if (src.x == null || tgt.x == null) continue;
+
+            l.currentAlpha = lerp(l.currentAlpha, l.targetAlpha, smoothing);
+
+            linkGfx.lineStyle(1, l.active ? color : mutedColor, l.currentAlpha);
+            linkGfx.moveTo(src.x, src.y);
+            linkGfx.lineTo(tgt.x, tgt.y);
+        }
+
+        app.render();
+        requestAnimationFrame(animate);
     }
 
-    function closefullGraph(fullGraph) {
-        if (fullGraph) {
-            fullGraph._destructor();
-        }
-        return null;
+    requestAnimationFrame(animate);
+
+    // Zoom to fit after simulation settles
+    if (isFullScreen || graphData.nodes.length > 4) {
+        setTimeout(() => {
+            let minX = Infinity, maxX = -Infinity, minY = Infinity, maxY = -Infinity;
+            for (const n of nodes) {
+                if (n.x == null || n.y == null) continue;
+                minX = Math.min(minX, n.x);
+                maxX = Math.max(maxX, n.x);
+                minY = Math.min(minY, n.y);
+                maxY = Math.max(maxY, n.y);
+            }
+            if (minX === Infinity) return;
+
+            const padding = 50;
+            const gw = (maxX - minX) + padding * 2;
+            const gh = (maxY - minY) + padding * 2;
+            const k = Math.min(width / gw, height / gh, 2);
+            const cx = (minX + maxX) / 2;
+            const cy = (minY + maxY) / 2;
+
+            const transform = zoomIdentity
+                .translate(width / 2 - cx * k, height / 2 - cy * k)
+                .scale(k);
+
+            select(app.view).call(zoomBehavior.transform, transform);
+        }, 500);
     }
+
+    return function cleanup() {
+        stopAnimation = true;
+        simulation.stop();
+        select(app.view).on('.drag', null).on('.zoom', null);
+        app.destroy(true, { children: true });
+    };
+}
+
+// --- Initialize ---
+let graphDataCache = null;
+let fullGraphDataCache = null;
+let localGraphCleanup = null;
+let globalGraphCleanup = null;
+
+async function init() {
+    const { graphData, fullGraphData } = await fetchGraphData();
+    graphDataCache = graphData;
+    fullGraphDataCache = fullGraphData;
+    renderLocal();
+}
+
+function renderLocal() {
+    if (localGraphCleanup) {
+        localGraphCleanup();
+        localGraphCleanup = null;
+    }
+    const data = filterLocalGraphData(graphDataCache);
+    const cleanup = renderGraph(data, 'link-graph', false);
+    localGraphCleanup = cleanup;
+}
+
+function openModal(data) {
+    if (globalGraphCleanup) {
+        globalGraphCleanup();
+        globalGraphCleanup = null;
+    }
+    document.getElementById('full-graph').style.display = '';
+    setTimeout(() => {
+        globalGraphCleanup = renderGraph(data, 'full-graph-container', true);
+        lucide.createIcons({ attrs: { class: ['svg-icon'] } });
+    }, 50);
+}
+
+function openFullGraph() {
+    openModal(fullGraphDataCache);
+}
+
+function openExpandedLocal() {
+    openModal(filterLocalGraphData(graphDataCache));
+}
+
+function closeFullGraph() {
+    if (globalGraphCleanup) {
+        globalGraphCleanup();
+        globalGraphCleanup = null;
+    }
+    document.getElementById('full-graph').style.display = 'none';
+}
+
+// Expose to Alpine
+window.__graph = { openFullGraph, closeFullGraph, openExpandedLocal, rerenderLocal: renderLocal };
+init();
 </script>
-<div  x-init="{graphData, fullGraphData} = await fetchGraphData();" x-data="{ graphData: null, depth: 1, graph: null, fullGraph: null, showFullGraph: false, fullScreen: false, fullGraphData: null}" id="graph-component" x-bind:class="fullScreen ? 'graph graph-fs' : 'graph'" v-scope>
+
+<div id="graph-component" class="graph" x-data="{ showFullGraph: false }">
     <div class="graph-title-container">
         <div class="graph-title">Connected Pages</div>
         <div id="graph-controls">
-                <div class="depth-control">
-                    <label for="graph-depth">Depth</label>
-                    <div class="slider">
-                            <input x-model.number="depth" name="graph-depth" list="depthmarkers" type="range" step="1" min="1" max="3" id="graph-depth"/>
-                    <datalist id="depthmarkers">
-                            <option value="1" label="1"></option>
-                            <option value="2" label="2"></option>
-                            <option value="3" label="3"></option>
-                    </datalist>
-                    </div>
-                    <span id="depth-display" x-text="depth"></span>
-                </div>
-                <div class="ctrl-right">
-                    <span id="global-graph-btn" x-on:click="showFullGraph = true; setTimeout(() => {fullGraph = openFullGraph(fullGraphData)}, 100)"><i  data-lucide="globe" aria-hidden="true"></i></span>
-                    <span  id="graph-fs-btn"  x-on:click="fullScreen = !fullScreen"><i  data-lucide="expand" aria-hidden="true"></i></span>
-                </div>
+            <div class="ctrl-right">
+                <span id="global-graph-btn" x-on:click="showFullGraph = true; window.__graph.openFullGraph()"><i data-lucide="globe" aria-hidden="true"></i></span>
+                <span id="graph-fs-btn" x-on:click="showFullGraph = true; window.__graph.openExpandedLocal()"><i data-lucide="expand" aria-hidden="true"></i></span>
+            </div>
         </div>
     </div>
-    <div x-effect="window.graph = renderLocalGraph(graphData, depth, fullScreen)" id="link-graph" ></div>
+    <div id="link-graph"></div>
     <div x-show="showFullGraph" id="full-graph" class="show" style="display: none;">
-        <span id="full-graph-close" x-on:click="fullGraph = closefullGraph(fullGraph); showFullGraph = false;"><i data-lucide="x" aria-hidden="true"></i></span><div id="full-graph-container"></div>
+        <span id="full-graph-close" x-on:click="window.__graph.closeFullGraph(); showFullGraph = false;"><i data-lucide="x" aria-hidden="true"></i></span>
+        <div id="full-graph-container"></div>
     </div>
 </div>

--- a/src/site/_includes/components/pageheader.njk
+++ b/src/site/_includes/components/pageheader.njk
@@ -11,6 +11,18 @@
     {% endfor %}
 {% endif %}
 
+<script type="importmap">
+{
+  "imports": {
+    "d3-force": "https://cdn.jsdelivr.net/npm/d3-force@3.0.0/+esm",
+    "d3-selection": "https://cdn.jsdelivr.net/npm/d3-selection@3.0.0/+esm",
+    "d3-zoom": "https://cdn.jsdelivr.net/npm/d3-zoom@3.0.0/+esm",
+    "d3-drag": "https://cdn.jsdelivr.net/npm/d3-drag@3.0.0/+esm"
+  }
+}
+</script>
+<script src="https://cdn.jsdelivr.net/npm/pixi.js@7.4.2/dist/pixi.min.js"></script>
+
 <script async type="module">
     import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
     mermaid.initialize({ startOnLoad: true });
@@ -19,8 +31,6 @@
 <script async src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.25.0/plugins/autoloader/prism-autoloader.min.js" integrity="sha512-sv0slik/5O0JIPdLBCR2A3XDg/1U3WuDEheZfI/DI5n8Yqc3h5kjrnr46FGBNiUAJF7rE4LHKwQ/SoSLRKAxEA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 
 {%include "components/calloutScript.njk"%}
-
-<script defer src="https://fastly.jsdelivr.net/npm/force-graph@1.43.0/dist/force-graph.min.js"></script>
 
 <script defer src="https://fastly.jsdelivr.net/npm/@alpinejs/persist@3.11.1/dist/cdn.min.js"></script>
 <script defer src="https://fastly.jsdelivr.net/npm/alpinejs@3.11.1/dist/cdn.min.js"></script>

--- a/src/site/styles/digital-garden-base.scss
+++ b/src/site/styles/digital-garden-base.scss
@@ -29,8 +29,13 @@ body {
     --dg-graph-height: 250px;
     --dg-graph-border-radius: 10px;
     --dg-graph-margin-bottom: 20px;
-    --dg-graph-fullscreen-width: 600px;
-    --dg-graph-fullscreen-height: 600px;
+    --dg-graph-fullscreen-width: 90vw;
+    --dg-graph-fullscreen-height: 85vh;
+    --dg-graph-node-color: var(--text-accent);
+    --dg-graph-node-color-muted: var(--text-faint);
+    --dg-graph-label-color: var(--text-normal);
+    --dg-graph-bg: var(--background-primary);
+    --dg-graph-border-color: var(--background-secondary);
 
     /* Filetree (Left Sidebar) Variables */
     --dg-filetree-width: 250px;
@@ -111,8 +116,6 @@ body {
     --dg-graph-ctrl-size: 0.7rem;
     --dg-graph-ctrl-icon-size: 14px;
     --dg-graph-ctrl-gap: 10px;
-    --dg-depth-slider-width: 50px;
-    --dg-depth-display-size: 1.1rem;
 
     /* Timestamps Variables */
     --dg-timestamps-size: 0.8em;
@@ -132,8 +135,8 @@ body {
     --note-icon-2: url(/img/tree-2.svg);
     --note-icon-3: url(/img/tree-3.svg);
     --note-icon-fallback: url(/img/default-note-icon.svg);
-    --graph-main: var(--text-accent);
-    --graph-muted: var(--text-muted);
+    --graph-main: var(--dg-graph-node-color);
+    --graph-muted: var(--dg-graph-node-color-muted);
 }
 
 .markdown-preview-view {
@@ -378,39 +381,6 @@ body:has(.content.canvas-page) .sidebar {
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
 }
 
-// Fullscreen graph - outside sidebar to avoid containment issues
-.graph-fs {
-    position: fixed !important;
-    top: 50% !important;
-    left: 50% !important;
-    width: var(--dg-graph-fullscreen-width) !important;
-    height: var(--dg-graph-fullscreen-height) !important;
-    max-width: 90vw !important;
-    max-height: 90vh !important;
-    transform: translate(-50%, -50%);
-    z-index: 9999;
-    display: flex !important;
-    flex-direction: column;
-    background-color: var(--background-secondary);
-    border: 1px solid var(--text-accent);
-    border-radius: var(--dg-graph-border-radius);
-    padding: var(--dg-mermaid-padding);
-
-    #link-graph {
-        width: 100% !important;
-        height: 100% !important;
-        flex: 1;
-    }
-
-    #graph-controls {
-        margin-top: 10px;
-        flex-shrink: 0;
-    }
-
-    .graph-title {
-        display: none;
-    }
-}
 
 .expand-line {
     display: flex;
@@ -557,10 +527,17 @@ body:has(.content.canvas-page) .sidebar {
 }
 
 #link-graph {
-    background-color: var(--background-secondary);
+    background-color: var(--dg-graph-bg);
     margin-bottom: var(--dg-graph-margin-bottom);
     border-radius: var(--dg-graph-border-radius);
+    border: 1px solid var(--dg-graph-border-color);
     width: fit-content;
+
+    canvas {
+        display: block;
+        width: 100%;
+        height: 100%;
+    }
 }
 
 @media (max-width: 1400px) {
@@ -1325,31 +1302,44 @@ body.has-navbar .content {
 
 #full-graph {
     position: fixed;
-    top: 50%;
-    left: 50%;
-    width: var(--dg-graph-fullscreen-width);
-    height: var(--dg-graph-fullscreen-height);
-    max-width: 90vw;
-    max-height: 90vh;
-    transform: translate(-50%, -50%);
+    top: 0;
+    left: 0;
+    width: 100vw;
+    height: 100vh;
     z-index: 9999;
     display: none;
-    background-color: var(--background-secondary);
-    border: 1px solid var(--text-accent);
-    border-radius: var(--dg-graph-border-radius);
-    padding: var(--dg-mermaid-padding);
+    background-color: color-mix(in srgb, var(--background-secondary) 85%, transparent);
+    backdrop-filter: blur(4px);
 
     #full-graph-container {
-        width: 100%;
-        height: calc(100% - 30px);
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+        width: var(--dg-graph-fullscreen-width);
+        height: var(--dg-graph-fullscreen-height);
+        background-color: var(--dg-graph-bg);
+        border: 1px solid var(--dg-graph-border-color);
+        border-radius: var(--dg-graph-border-radius);
+
+        canvas {
+            display: block;
+            width: 100%;
+            height: 100%;
+        }
     }
 
     #full-graph-close {
         position: absolute;
-        top: 10px;
-        right: 10px;
+        top: 20px;
+        right: 20px;
         cursor: pointer;
-        z-index: 9;
+        z-index: 10;
+        color: var(--text-muted);
+
+        &:hover {
+            color: var(--text-normal);
+        }
     }
 }
 
@@ -1400,73 +1390,6 @@ body.has-navbar .content {
         }
     }
 
-    .depth-control {
-        display: flex;
-        flex-direction: row;
-        align-items: center;
-        gap: 8px;
-
-        label {
-            font-size: var(--dg-graph-ctrl-size);
-            opacity: 0.6;
-        }
-
-        .slider {
-            width: var(--dg-depth-slider-width);
-            display: flex;
-            align-items: center;
-
-            input[type="range"] {
-                width: 100%;
-                height: 4px;
-                -webkit-appearance: none;
-                appearance: none;
-                background: var(--text-muted);
-                border-radius: 2px;
-                outline: none;
-
-                &::-webkit-slider-thumb {
-                    -webkit-appearance: none;
-                    appearance: none;
-                    width: 12px;
-                    height: 12px;
-                    background: var(--text-normal);
-                    border-radius: 50%;
-                    cursor: pointer;
-                }
-
-                &::-moz-range-thumb {
-                    width: 12px;
-                    height: 12px;
-                    background: var(--text-normal);
-                    border-radius: 50%;
-                    cursor: pointer;
-                    border: none;
-                }
-            }
-
-            datalist {
-                display: none;
-            }
-        }
-
-        #depth-display {
-            background-color: var(--text-accent);
-            color: var(--background-primary);
-            min-width: var(--dg-depth-display-size);
-            height: var(--dg-depth-display-size);
-            font-size: 0.65rem;
-            display: flex;
-            justify-content: center;
-            align-items: center;
-            border-radius: 50%;
-            font-weight: 600;
-        }
-    }
-}
-
-input[type="range"]::-webkit-slider-thumb {
-    -webkit-appearance: none;
 }
 
 body.title-note-icon .cm-s-obsidian > header > h1[data-note-icon]::before,


### PR DESCRIPTION
Pixi uses webGL. The old implementation used force-graph.js that was rendering on a 2D canvas. This rewrite makes the graph much more performant, resulting in it feeling much smoother. There has also been some minor UI changes to make the graph look cleaner. It now only shows titles when zoomed in. And the full screen is actually full screen instead of just a slightly larger centered view.