### PR TITLE
fix: ignore links in code blocks and comments

### DIFF
--- a/src/helpers/linkUtils.js
+++ b/src/helpers/linkUtils.js
@@ -16,11 +16,19 @@ try {
   // bases-engine not available, skip bases link extraction
 }
 
+function stripIgnoredLinkContent(content) {
+  return (content || "")
+    .replace(/```[\s\S]*?```/g, "")
+    .replace(/<!--[\s\S]*?-->/g, "");
+}
+
 function extractLinks(content) {
+  const searchableContent = stripIgnoredLinkContent(content);
+
   // Extract iframe sources for canvas embeds
   const iframeLinks = [];
   let match;
-  while ((match = iframeSrcRegex.exec(content)) !== null) {
+  while ((match = iframeSrcRegex.exec(searchableContent)) !== null) {
     // match[1] is the captured path like "/notes/some-page/"
     iframeLinks.push(match[1]);
   }
@@ -28,7 +36,7 @@ function extractLinks(content) {
   iframeSrcRegex.lastIndex = 0;
 
   return [
-    ...(content.match(wikiLinkRegex) || []).map(
+    ...(searchableContent.match(wikiLinkRegex) || []).map(
       (link) =>
         link
           .slice(2, -2)
@@ -38,7 +46,7 @@ function extractLinks(content) {
           .trim()
           .split("#")[0]
     ),
-    ...(content.match(internalLinkRegex) || []).map(
+    ...(searchableContent.match(internalLinkRegex) || []).map(
       (link) =>
         link
           .slice(6, -1)

--- a/src/helpers/linkUtils.test.js
+++ b/src/helpers/linkUtils.test.js
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+
+const { extractLinks } = require("./linkUtils");
+
+describe("extractLinks", () => {
+  it("ignores internal links inside fenced code blocks and HTML comments", () => {
+    const content = `
+Actual page link: <a href="/coffees">Coffees</a>
+[[Public Wiki|Public]]
+
+\`\`\`html
+<div class="dropdown-menu">
+  <!--<li><a href="/">Home</a></li>-->
+  <li><a href="/code-only">Code only</a></li>
+</div>
+\`\`\`
+
+<!-- <a href="/comment-only">Comment only</a> -->
+[[Wiki Note]]
+`;
+
+    expect(extractLinks(content)).toEqual(["Public Wiki", "/coffees"]);
+  });
+
+  it("ignores wikilinks and canvas iframes inside fenced code blocks", () => {
+    const content = `
+<iframe src="/canvas-note/" class="canvas-file-iframe"></iframe>
+
+\`\`\`md
+[[Hidden Wiki|Hidden]]
+<iframe src="/hidden-canvas/" class="canvas-file-iframe"></iframe>
+\`\`\`
+`;
+
+    expect(extractLinks(content)).toEqual(["/canvas-note/"]);
+  });
+});


### PR DESCRIPTION
<!-- hermes-auto-maintainer -->

## Summary
- Strip fenced code blocks and HTML comments before extracting graph/backlink links.
- Keep normal wiki links, internal anchors, and canvas iframe links discoverable outside ignored content.
- Add regression coverage for links inside fenced code blocks and HTML comments.

Fixes #374

## Test Plan
- `npm test -- --run src/helpers/linkUtils.test.js`
- `git diff --check`
- `npm run build`

## Notes
- `npm test` currently fails on the existing `src/helpers/filetreeUtils.test.js` suite because that file uses Vitest globals without importing them (`ReferenceError: describe is not defined`). The new focused regression test and build pass.
