### PR TITLE
fix(nav-order): respect navigation order for notes using path rewrite rules

### DIFF
--- a/src/helpers/filetreeUtils.js
+++ b/src/helpers/filetreeUtils.js
@@ -130,7 +130,14 @@ function getPermalinkMeta(note, key) {
         folders = []; // Handle unexpected cases gracefully
       }
     }
-    folders[folders.length - 1]+= ".md";
+    // Path rewrite rules produce a dg-path that already includes the ".md"
+    // extension (e.g. "Path Rewriting/note.md" -> "note.md"). Strip it before
+    // re-appending so we don't end up with a double extension ("note.md.md"),
+    // which would prevent the stem-based navigation ordering from matching.
+    const lastFolder = folders[folders.length - 1];
+    folders[folders.length - 1] =
+      (lastFolder.endsWith(".md") ? lastFolder.slice(0, -3) : lastFolder) +
+      ".md";
   } catch {
     //ignore
   }
@@ -139,9 +146,9 @@ function getPermalinkMeta(note, key) {
 }
 
 function assignNested(obj, keyPath, value) {
-  lastKeyIndex = keyPath.length - 1;
-  for (var i = 0; i < lastKeyIndex; ++i) {
-    key = keyPath[i];
+  const lastKeyIndex = keyPath.length - 1;
+  for (let i = 0; i < lastKeyIndex; ++i) {
+    const key = keyPath[i];
     if (!(key in obj)) {
       obj[key] = { isFolder: true };
     }

--- a/src/helpers/filetreeUtils.test.js
+++ b/src/helpers/filetreeUtils.test.js
@@ -1,4 +1,5 @@
-const { getFileTree } = require("./filetreeUtils");
+import { describe, it, expect } from "vitest";
+import { getFileTree } from "./filetreeUtils.js";
 
 // Helper to build a minimal note object for testing
 function makeNote(filePathStem, data = {}) {
@@ -147,6 +148,69 @@ describe("filetreeUtils", () => {
       expect(keys[0]).toBe("gamma.md");
       expect(keys[1]).toBe("alpha.md");
       expect(keys[2]).toBe("beta.md");
+    });
+
+    it("respects ordering for notes with dg-path from rewrite rules (.md extension)", () => {
+      // Path rewrite rules produce a dg-path that includes the ".md" extension
+      // (e.g. "Path Rewriting/note.md" -> dg-path "note.md"). The navigation
+      // ordering stored by the plugin uses stems without the extension.
+      const data = {
+        collections: {
+          note: [
+            makeNote("/zebra", { "dg-path": "zebra.md" }),
+            makeNote("/alpha", { "dg-path": "alpha.md" }),
+            makeNote("/beta", { "dg-path": "beta.md" }),
+          ],
+        },
+        navigationOrder: {
+          "/": ["beta", "zebra", "alpha"],
+        },
+      };
+
+      const tree = getFileTree(data);
+      const keys = Object.keys(tree);
+
+      expect(keys[0]).toBe("beta.md");
+      expect(keys[1]).toBe("zebra.md");
+      expect(keys[2]).toBe("alpha.md");
+    });
+
+    it("respects ordering for nested folders from rewrite rules (.md extension)", () => {
+      const data = {
+        collections: {
+          note: [
+            makeNote("/old/zebra", { "dg-path": "renamed/zebra.md" }),
+            makeNote("/old/alpha", { "dg-path": "renamed/alpha.md" }),
+            makeNote("/old/middle", { "dg-path": "renamed/middle.md" }),
+          ],
+        },
+        navigationOrder: {
+          "/renamed": ["middle", "zebra", "alpha"],
+        },
+      };
+
+      const tree = getFileTree(data);
+      const folderKeys = Object.keys(tree["renamed"]).filter(
+        (k) => k !== "isFolder"
+      );
+
+      expect(folderKeys[0]).toBe("middle.md");
+      expect(folderKeys[1]).toBe("zebra.md");
+      expect(folderKeys[2]).toBe("alpha.md");
+    });
+
+    it("preserves dots in note names that are not the .md extension", () => {
+      const data = {
+        collections: {
+          note: [makeNote("/my-note-v1.2", { "dg-path": "my-note-v1.2" })],
+        },
+      };
+
+      const tree = getFileTree(data);
+      const keys = Object.keys(tree);
+
+      // The dot in "v1.2" must not be treated as an extension boundary
+      expect(keys).toEqual(["my-note-v1.2.md"]);
     });
 
     it("falls back to default sort when navigationOrder is empty object", () => {


### PR DESCRIPTION
## Problem

Fixes #786 — navigation order is silently ignored for any note affected by a **path rewrite rule**, even after re-checking and re-saving the order in the plugin.

## Root cause

When a path rewrite rule applies, the plugin writes a `dg-path` into the published frontmatter that **includes the `.md` extension** (e.g. `Path Rewriting/note.md` → `dg-path: note.md`).

`getPermalinkMeta` in `filetreeUtils.js` built the file-tree leaf key with `folders[last] += ".md"`, assuming `dg-path` had no extension (true for manually-set `dg-path` and for `filePathStem`, which Eleventy strips). For rewrite-rule notes this produced a **double extension**: `note.md.md`.

The stored `navigationOrder` uses stems (`note`), and `sortTree`'s resolver only tries `note` / `note.md`. The `note.md.md` key never matched, so the note dropped to default sort and the custom order was lost. This is why the bug only appears with rewrite rules.

## Fix

Strip a trailing `.md` before re-appending it, so leaf keys are always single-extension regardless of whether `dg-path` carried the extension. Only `.md` is stripped (not arbitrary dots), so names like `my-note-v1.2` are preserved.

Also in this change:
- Declared the implicit globals in `assignNested` (previously only worked in CommonJS sloppy mode; threw under strict/ESM and leaked globals).
- Converted `filetreeUtils.test.js` to ESM imports so it actually runs under `vitest run` (it was using jest-style globals and not running in the suite).

## Tests

Added 3 tests covering the rewrite-rule scenario (root, nested folder, and dot-in-name). Confirmed they fail before the fix (`note.md.md` keys) and pass after.

```
Test Files  6 passed (6)
     Tests  223 passed (223)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)