### PR TITLE
Fix anchor links breaking in notes with '&' in their path

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -57,14 +57,14 @@ function getAnchorAttributes(filePath, linkTitle) {
   let fileName = filePath.replaceAll("&amp;", "&");
   let header = "";
   let headerLinkPath = "";
-  if (filePath.includes("#")) {
-    [fileName, header] = filePath.split("#");
+  if (fileName.includes("#")) {
+    [fileName, header] = fileName.split("#");
     headerLinkPath = `#${headerToId(header)}`;
   }
 
   let noteIcon = process.env.NOTE_ICON_DEFAULT;
   const title = linkTitle ? linkTitle : fileName;
-  let permalink = `/notes/${slugify(filePath)}`;
+  let permalink = `/notes/${slugify(fileName)}`;
   let deadLink = false;
   try {
     const startPath = "./src/site/notes/";

--- a/src/helpers/__tests__/anchorAttributes.test.js
+++ b/src/helpers/__tests__/anchorAttributes.test.js
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+
+// Reproduces the decode-then-split logic from getAnchorAttributes in .eleventy.js.
+// This guards against the regression where filePath was split instead of the
+// already-decoded fileName, leaving &amp; in the resolved path.
+function decodeAndSplit(filePath) {
+  let fileName = filePath.replaceAll("&amp;", "&");
+  let header = "";
+  if (fileName.includes("#")) {
+    [fileName, header] = fileName.split("#");
+  }
+  return { fileName, header };
+}
+
+describe("getAnchorAttributes &amp; + # decode/split logic", () => {
+  it("decodes &amp; in path that also contains a heading anchor", () => {
+    const filePath =
+      "Software Engineering/11 AI &amp; ML/LLM/RAG/Monitoring#Retrieval Quality Metrics";
+
+    const { fileName, header } = decodeAndSplit(filePath);
+
+    expect(fileName).toBe(
+      "Software Engineering/11 AI & ML/LLM/RAG/Monitoring",
+    );
+    expect(header).toBe("Retrieval Quality Metrics");
+  });
+
+  it("decodes &amp; in path with no heading anchor", () => {
+    const { fileName, header } = decodeAndSplit(
+      "Notes/AI &amp; ML/Overview",
+    );
+    expect(fileName).toBe("Notes/AI & ML/Overview");
+    expect(header).toBe("");
+  });
+
+  it("handles heading anchor in path without &amp;", () => {
+    const { fileName, header } = decodeAndSplit("Notes/Overview#Introduction");
+    expect(fileName).toBe("Notes/Overview");
+    expect(header).toBe("Introduction");
+  });
+
+  it("returns unchanged path when neither &amp; nor # present", () => {
+    const { fileName, header } = decodeAndSplit("Notes/Simple Note");
+    expect(fileName).toBe("Notes/Simple Note");
+    expect(header).toBe("");
+  });
+});


### PR DESCRIPTION
When a wiki-link points to a heading inside a note whose folder path contains & (e.g. AI & ML), the link resolves to /404 instead of the correct URL.

### Why it happens

markdown-it HTML-encodes `&` to `&amp`, when rendering note content. getAnchorAttributes correctly decodes it back on the first line, but when the link also contains a `#` heading anchor, the if block re-splits from the original filePath, which still has `&amp`, overwriting the decoded value. So fs.readFileSync gets a path like `notes/AI &amp; ML/...` which doesn't exist, and the link falls back to /404.

### The fix

Split on fileName (already decoded) instead of filePath:
```
if (fileName.includes("#")) {
  [fileName, header] = fileName.split("#");
  ...
}
```
### How to reproduce

Have a note at notes/AI & ML/Topic.md with a heading ## My Section
Link to it from another note: [[AI & ML/Topic#My Section|click here]]
Build and observe the link renders as href="/404"