### PR TITLE
feat: dg-hide hides everywhere (search, graph, backlinks, feed, sitemap)

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -755,6 +755,10 @@ module.exports = function(eleventyConfig) {
     return JSON.stringify(variable) || '""';
   });
 
+  eleventyConfig.addFilter("notHidden", function (arr) {
+    return (arr || []).filter((item) => !item.data.hide);
+  });
+
   eleventyConfig.addFilter("validJson", function(variable) {
     if (Array.isArray(variable)) {
       return variable.map((x) => x.replaceAll("\\", "\\\\")).join(",");

--- a/src/helpers/filetreeUtils.js
+++ b/src/helpers/filetreeUtils.js
@@ -113,8 +113,8 @@ function getPermalinkMeta(note, key) {
     }
     // Reason for adding the hide flag instead of removing completely from file tree is to
     // allow users to use the filetree data elsewhere without the fear of losing any data.
-    if (note.data.hide) {
-      hide = note.data.hide;
+    if (note.data.hide || note.data.hideInFiletree) {
+      hide = true;
     }
     if (note.data.pinned) {
       pinned = note.data.pinned;

--- a/src/helpers/filetreeUtils.test.js
+++ b/src/helpers/filetreeUtils.test.js
@@ -231,4 +231,30 @@ describe("filetreeUtils", () => {
       expect(keys[1]).toBe("zebra.md");
     });
   });
+
+  describe("hide flags", () => {
+    it("does not hide a normal note", () => {
+      const data = { collections: { note: [makeNote("/normal")] } };
+      const tree = getFileTree(data);
+      expect(tree["normal.md"].hide).toBeFalsy();
+    });
+
+    it("hides a note with hide:true (dg-hide)", () => {
+      const data = {
+        collections: { note: [makeNote("/secret", { hide: true })] },
+      };
+      const tree = getFileTree(data);
+      expect(tree["secret.md"].hide).toBe(true);
+    });
+
+    it("hides a note with hideInFiletree:true (dg-hide-in-filetree)", () => {
+      const data = {
+        collections: {
+          note: [makeNote("/treeonly", { hideInFiletree: true })],
+        },
+      };
+      const tree = getFileTree(data);
+      expect(tree["treeonly.md"].hide).toBe(true);
+    });
+  });
 });

--- a/src/helpers/linkUtils.js
+++ b/src/helpers/linkUtils.js
@@ -131,7 +131,8 @@ async function getGraph(data) {
       neighbors: new Set(),
       backLinks: new Set(),
       noteIcon: v.data.noteIcon || process.env.NOTE_ICON_DEFAULT,
-      hide: v.data.hideInGraph || false,
+      hide: v.data.hide || v.data.hideInGraph || false,
+      private: v.data.hide || false,
     };
     stemURLs[fpath] = v.url;
     if (

--- a/src/helpers/linkUtils.test.js
+++ b/src/helpers/linkUtils.test.js
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { getGraph } from "./linkUtils.js";
+
+// Minimal note stub matching what getGraph reads.
+function makeNote(slug, data = {}) {
+  return {
+    filePathStem: `/notes/${slug}`,
+    url: `/${slug}/`,
+    fileSlug: slug,
+    data: { title: slug, ...data },
+    template: { read: async () => ({ content: "" }) },
+  };
+}
+
+async function buildGraph(notes) {
+  return getGraph({ collections: { note: notes } });
+}
+
+describe("linkUtils getGraph hide flags", () => {
+  it("does not hide or privatize a normal note", async () => {
+    const graph = await buildGraph([makeNote("normal")]);
+    expect(graph.nodes["/normal/"].hide).toBe(false);
+    expect(graph.nodes["/normal/"].private).toBe(false);
+  });
+
+  it("hides and privatizes a note with hide:true (dg-hide)", async () => {
+    const graph = await buildGraph([makeNote("secret", { hide: true })]);
+    expect(graph.nodes["/secret/"].hide).toBe(true);
+    expect(graph.nodes["/secret/"].private).toBe(true);
+  });
+
+  it("hides but does not privatize a note with hideInGraph:true", async () => {
+    const graph = await buildGraph([
+      makeNote("graphonly", { hideInGraph: true }),
+    ]);
+    expect(graph.nodes["/graphonly/"].hide).toBe(true);
+    expect(graph.nodes["/graphonly/"].private).toBe(false);
+  });
+
+  it("does not hide a filetree-only note from the graph", async () => {
+    const graph = await buildGraph([
+      makeNote("treeonly", { hideInFiletree: true }),
+    ]);
+    expect(graph.nodes["/treeonly/"].hide).toBe(false);
+    expect(graph.nodes["/treeonly/"].private).toBe(false);
+  });
+});

--- a/src/site/_includes/components/sidebar.njk
+++ b/src/site/_includes/components/sidebar.njk
@@ -63,7 +63,7 @@
                                                       </div>
                                                 {%- endif -%}
                                                 {%- for backlink in currentNode.backLinks -%}
-                                                      {%- if graph.nodes[backlink].url != page.url -%}
+                                                      {%- if graph.nodes[backlink].url != page.url and not graph.nodes[backlink].private -%}
                                                       <div class="backlink-card">
                                                             {%- if not meta.noteIconsSettings.backlinks -%}<i  data-lucide="link"></i> {%- endif -%}<a href="{{graph.nodes[backlink].url}}" data-note-icon="{{graph.nodes[backlink].noteIcon}}" class="backlink">{{graph.nodes[backlink].title}}</a>
                                                       </div>

--- a/src/site/feed.njk
+++ b/src/site/feed.njk
@@ -12,7 +12,7 @@
   <link href="{{ meta.siteBaseUrl }}"/>
   <updated>{{ collections.notes | getNewestCollectionItemDate | dateToRfc3339 }}</updated>
   <id>{{ meta.siteBaseUrl }}</id>
-  {%- for note in collections.note | reverse -%}
+  {%- for note in (collections.note | notHidden) | reverse -%}
   {%- if note.url != "/" -%}
   <entry>
     <title>{%- if note.title -%}{{ note.title }}{%- else -%}{{ note.fileSlug }}{%- endif -%}</title>

--- a/src/site/search-index.njk
+++ b/src/site/search-index.njk
@@ -2,7 +2,7 @@
 permalink: /searchIndex.json
 eleventyExcludeFromCollections: true
 ---
-[{% for post in collections.note %}
+[{% for post in collections.note | notHidden %}
 {
 		"title": {% if post.data.title %}{{post.data.title | jsonify | safe }}{% else %}{{post.fileSlug | jsonify | safe }}{% endif %},
 		"date":"{{ post.date }}",

--- a/src/site/sitemap.njk
+++ b/src/site/sitemap.njk
@@ -5,9 +5,11 @@ eleventyExcludeFromCollections: true
 <?xml version="1.0" encoding="utf-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
     {% for page in collections.all %}
+        {% if not page.data.hide %}
         <url>
             <loc>{{ meta.siteBaseUrl }}{{ page.url | url }}</loc>
             <lastmod>{%if page.data.updated %}{{ page.data.updated | dateToZulu }}{%else%}{{ page.date | dateToZulu }}{%endif%}</lastmod>
         </url>
+        {% endif %}
     {% endfor %}
 </urlset>


### PR DESCRIPTION
## Summary

Template half of the `dg-hide` rework. Makes published notes honor three independent hide flags written by the Obsidian plugin (companion PR: oleeskild/obsidian-digital-garden#796):

- **`hide`** (`dg-hide`) — hide everywhere: filetree, search, graph, backlinks, RSS feed, sitemap. Page still reachable by URL.
- **`hideInFiletree`** (`dg-hide-in-filetree`) — filetree only.
- **`hideInGraph`** (`dg-hide-in-graph`) — graph only (unchanged).

Implements #708 and #295; resolves #240 / #726.

## Changes
- `src/helpers/filetreeUtils.js` — filetree hides on `hide || hideInFiletree`.
- `src/helpers/linkUtils.js` — graph node `hide = hide || hideInGraph`; new `private = hide` flag.
- `src/site/_includes/components/sidebar.njk` — backlinks skip `private` notes.
- `.eleventy.js` — new `notHidden` filter.
- `src/site/search-index.njk`, `feed.njk` — filter through `notHidden`.
- `src/site/sitemap.njk` — skip `page.data.hide`.
- Vitest coverage for filetree + graph hide logic.

## ⚠️ Breaking change
Notes previously using `dg-hide` for filetree-only decluttering will now also leave search/graph/feed/sitemap. Migrate those to `dg-hide-in-filetree`.

## Known / intentional (not addressed here)
- `dg-hide` notes stay reachable by direct URL by design.
- `graph.json` still physically ships hidden nodes; the client renderer filters them (pre-existing behavior, same as `hideInGraph`).
- `random.njk` could still land on a hidden note — possible follow-up.

## Test Plan
- [x] `npx vitest run src/helpers/filetreeUtils.test.js src/helpers/linkUtils.test.js` — 17/17 pass
- [x] Build smoke test with fixture notes: `dg-hide` note absent from `searchIndex.json`, `sitemap.xml`, and `feed.xml` entries; valid search JSON; `dg-hide-in-filetree` note still present in search/sitemap

🤖 Generated with [Claude Code](https://claude.com/claude-code)