### PR TITLE
fix(bases): parse date-only strings as local calendar days

### DIFF
--- a/src/helpers/bases-engine/__tests__/exprEval.test.js
+++ b/src/helpers/bases-engine/__tests__/exprEval.test.js
@@ -332,6 +332,14 @@ describe("exprEval", () => {
 			expect(evaluate("list(1, 2, 3)", sampleNote)).toEqual([1, 2, 3]);
 		});
 
+		it("date-only string uses local calendar day", () => {
+			const result = evaluate('date("2024-01-15")', sampleNote);
+			expect(result instanceof Date).toBe(true);
+			expect(result.getFullYear()).toBe(2024);
+			expect(result.getMonth()).toBe(0);
+			expect(result.getDate()).toBe(15);
+		});
+
 		it("date() returns Date object", () => {
 			const result = evaluate('date("2024-01-15")', sampleNote);
 			expect(result instanceof Date).toBe(true);

--- a/src/helpers/bases-engine/exprEval.js
+++ b/src/helpers/bases-engine/exprEval.js
@@ -465,7 +465,11 @@ function callGlobalFunction(name, args) {
 			return d;
 		}
 		case "date": {
-			const d = new Date(args[0]);
+			const value = args[0];
+			const dateOnly = typeof value === "string" && /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+			const d = dateOnly
+				? new Date(Number(dateOnly[1]), Number(dateOnly[2]) - 1, Number(dateOnly[3]))
+				: new Date(value);
 			return isNaN(d.getTime()) ? undefined : d;
 		}
 		case "if":


### PR DESCRIPTION
## Why
Bases `date("YYYY-MM-DD")` was parsed as UTC midnight, so in timezones west of UTC (e.g. Brazil) local day/month/year could land on the previous calendar day. Formulas and `.format()` should treat a bare date as that local calendar day.

## Summary
- Parse bare `YYYY-MM-DD` inputs in Bases `date()` as local calendar days instead of UTC midnight
- Keep full timestamps on the existing `new Date(value)` path

## Test plan
- [x] `TZ=UTC npx vitest run src/helpers/bases-engine/__tests__/exprEval.test.js`
- [ ] Verify a Bases formula using `date("2024-01-15")` shows Jan 15 locally