### PR TITLE
refactor(bases): extract render cache to break circular require

### DIFF
--- a/src/helpers/basesPlugin.js
+++ b/src/helpers/basesPlugin.js
@@ -1,19 +1,13 @@
 const { executeBaseQuery, renderViews } = require("./bases-engine");
 const linkUtils = require("./linkUtils");
+const {
+  clearRenderCache,
+  getRenderCache,
+  getRenderCacheBuildId,
+} = require("./basesRenderCache");
 
 // Cache rendered HTML keyed by YAML + notes fingerprint to avoid re-rendering
 // identical queries within a single build. Cleared between builds.
-const renderCache = new Map();
-let renderCacheBuildId = 0;
-
-/**
- * Clear the render cache. Call at the start of each build (e.g. --watch mode)
- * to avoid serving stale HTML across rebuilds.
- */
-function clearRenderCache() {
-  renderCache.clear();
-  renderCacheBuildId++;
-}
 
 function basesPlugin(md) {
   const origFence =
@@ -53,10 +47,11 @@ function notesFingerprint(notes) {
       hash = ((hash << 5) - hash + s.charCodeAt(i)) | 0;
     }
   }
-  return renderCacheBuildId + ":" + notes.length + ":" + hash;
+  return getRenderCacheBuildId() + ":" + notes.length + ":" + hash;
 }
 
 function renderBaseBlock(yamlContent, notes) {
+  const renderCache = getRenderCache();
   const cacheKey = yamlContent + "\0" + notesFingerprint(notes);
   if (renderCache.has(cacheKey)) return renderCache.get(cacheKey);
   const result = executeBaseQuery(yamlContent, notes);
@@ -69,4 +64,4 @@ function escapeHtml(str) {
   return String(str).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
 }
 
-module.exports = { basesPlugin, clearRenderCache };
+module.exports = { basesPlugin };

--- a/src/helpers/basesRenderCache.js
+++ b/src/helpers/basesRenderCache.js
@@ -1,0 +1,21 @@
+const renderCache = new Map();
+let renderCacheBuildId = 0;
+
+function clearRenderCache() {
+  renderCache.clear();
+  renderCacheBuildId++;
+}
+
+function getRenderCache() {
+  return renderCache;
+}
+
+function getRenderCacheBuildId() {
+  return renderCacheBuildId;
+}
+
+module.exports = {
+  clearRenderCache,
+  getRenderCache,
+  getRenderCacheBuildId,
+};

--- a/src/helpers/linkUtils.js
+++ b/src/helpers/linkUtils.js
@@ -11,7 +11,7 @@ let basesEngine = null;
 let clearRenderCache = null;
 try {
   basesEngine = require("./bases-engine");
-  clearRenderCache = require("./basesPlugin").clearRenderCache;
+  clearRenderCache = require("./basesRenderCache").clearRenderCache;
 } catch (e) {
   // bases-engine not available, skip bases link extraction
 }


### PR DESCRIPTION
## Why
`basesPlugin` requires `linkUtils`, and `linkUtils` needed `clearRenderCache` from `basesPlugin` — a circular dependency that makes the modules harder to load and reason about. Pulling the cache into its own module breaks that cycle without changing Bases behavior.

## Summary
- Move Bases render cache state into `src/helpers/basesRenderCache.js`
- Let `linkUtils` clear the cache without requiring `basesPlugin`

## Test plan
- [ ] `npm test`
- [ ] Build with a note containing a ` ```base ` block and confirm queries still render