### PR TITLE
fix(bases): compact note metadata for Bases queries

### DIFF
--- a/src/helpers/linkUtils.js
+++ b/src/helpers/linkUtils.js
@@ -16,6 +16,73 @@ try {
   // bases-engine not available, skip bases link extraction
 }
 
+const METADATA_EXCLUDE_KEYS = new Set([
+  "basesNotes",
+  "collections",
+  "content",
+  "eleventy",
+  "filetree",
+  "graph",
+  "layout",
+  "meta",
+  "noteProps",
+  "page",
+  "pagination",
+  "pkg",
+  "settings",
+  "templateContent",
+  "userComputed",
+]);
+
+function cloneMetadataValue(value, seen) {
+  if (value == null || typeof value !== "object") {
+    return value;
+  }
+
+  if (value instanceof Date) {
+    return value;
+  }
+
+  if (seen.has(value)) {
+    return undefined;
+  }
+  seen.add(value);
+
+  if (Array.isArray(value)) {
+    const items = value
+      .map((item) => cloneMetadataValue(item, seen))
+      .filter((item) => item !== undefined);
+    seen.delete(value);
+    return items;
+  }
+
+  const result = {};
+  for (const [key, childValue] of Object.entries(value)) {
+    if (typeof childValue === "function") continue;
+    const cloned = cloneMetadataValue(childValue, seen);
+    if (cloned !== undefined) {
+      result[key] = cloned;
+    }
+  }
+  seen.delete(value);
+  return result;
+}
+
+function compactNoteMetadata(data) {
+  const metadata = {};
+  for (const [key, value] of Object.entries(data || {})) {
+    if (METADATA_EXCLUDE_KEYS.has(key)) continue;
+    if (key.startsWith("eleventy")) continue;
+    if (typeof value === "function" || value === undefined) continue;
+
+    const cloned = cloneMetadataValue(value, new WeakSet());
+    if (cloned !== undefined) {
+      metadata[key] = cloned;
+    }
+  }
+  return metadata;
+}
+
 function extractLinks(content) {
   // Extract iframe sources for canvas embeds
   const iframeLinks = [];
@@ -178,7 +245,7 @@ async function getGraph(data) {
     return {
       path: item.filePathStem.replace("/notes/", ""),
       url: item.url,
-      metadata: item.data,
+      metadata: compactNoteMetadata(item.data),
       fileSlug: item.fileSlug,
       // Inject computed link data for bases queries
       _links: url.outBound || [],
@@ -223,4 +290,5 @@ exports.wikiLinkRegex = wikiLinkRegex;
 exports.internalLinkRegex = internalLinkRegex;
 exports.extractLinks = extractLinks;
 exports.getGraph = getGraph;
+exports.compactNoteMetadata = compactNoteMetadata;
 exports._basesNotesWithLinks = null;

--- a/src/helpers/linkUtils.test.mjs
+++ b/src/helpers/linkUtils.test.mjs
@@ -1,0 +1,41 @@
+import { createRequire } from "node:module";
+import { describe, expect, test } from "vitest";
+
+const require = createRequire(import.meta.url);
+const { compactNoteMetadata } = require("./linkUtils");
+
+describe("compactNoteMetadata", () => {
+  test("keeps base-query metadata without retaining Eleventy data graphs", () => {
+    const source = {
+      title: "Readable title",
+      tags: ["probability", "gardenEntry"],
+      permalink: "/notes/example/",
+      noteIcon: "sigma",
+      hide: false,
+      "dg-note-properties": {
+        author: "Ada",
+        status: "draft",
+      },
+      collections: { note: [{ data: { title: "recursive" } }] },
+      graph: { nodes: { a: {} }, links: [] },
+      basesNotes: [{ metadata: { basesNotes: [] } }],
+      filetree: { children: [] },
+      page: { inputPath: "source.md" },
+      pkg: { version: "test" },
+    };
+
+    const metadata = compactNoteMetadata(source);
+
+    expect(metadata).toEqual({
+      title: "Readable title",
+      tags: ["probability", "gardenEntry"],
+      permalink: "/notes/example/",
+      noteIcon: "sigma",
+      hide: false,
+      "dg-note-properties": {
+        author: "Ada",
+        status: "draft",
+      },
+    });
+  });
+});

--- a/src/site/notes/notes.11tydata.js
+++ b/src/site/notes/notes.11tydata.js
@@ -1,5 +1,6 @@
 require("dotenv").config();
 const settings = require("../../helpers/constants");
+const { compactNoteMetadata } = require("../../helpers/linkUtils");
 
 const allSettings = settings.ALL_NOTE_SETTINGS;
 
@@ -22,7 +23,7 @@ module.exports = {
       return data.collections.note.map((item) => ({
         path: item.filePathStem.replace("/notes/", ""),
         url: item.url,
-        metadata: item.data,
+        metadata: compactNoteMetadata(item.data),
         fileSlug: item.fileSlug,
       }));
     },


### PR DESCRIPTION
## Why
Bases notes were given `metadata: item.data`, i.e. the full Eleventy data cascade. That embeds `collections` / `graph` / `filetree` / `basesNotes` into every note, inflating memory on large vaults and creating circular structures. Bases formulas only need frontmatter-ish fields.

## Summary
- Add `compactNoteMetadata` to strip Eleventy internals from Bases note metadata
- Use it in graph `basesNotes` and `notes.11tydata.js`

## Test plan
- [x] `TZ=UTC npx vitest run src/helpers/linkUtils.test.mjs`
- [ ] Build a garden with Bases blocks on a large vault and confirm queries still work