### PR TITLE
fix: nested note permalinks in anchors and filetree

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -64,7 +64,7 @@ function getAnchorAttributes(filePath, linkTitle) {
 
   let noteIcon = process.env.NOTE_ICON_DEFAULT;
   const title = linkTitle ? linkTitle : fileName;
-  let permalink = `/notes/${slugify(fileName)}`;
+  let permalink = notePathToPermalink(fileName);
   let deadLink = false;
   try {
     const startPath = "./src/site/notes/";
@@ -114,6 +114,12 @@ function getAnchorAttributes(filePath, linkTitle) {
 }
 
 const tagRegex = /(^|\s|\>)(#[^\s!@#$%^&*()=+\.,\[{\]};:'"?><]+)(?!([^<]*>))/g;
+
+function notePathToPermalink(notePath) {
+  const segments = notePath.split("/").filter(Boolean);
+  const slugged = segments.map((segment) => slugify(segment));
+  return `/notes/${slugged.join("/")}/`;
+}
 
 const markdownFileTypeRegex = /\.(md|markdown)$/i;
 const isMarkdownPage = (inputPath) => inputPath && inputPath.match(markdownFileTypeRegex);

--- a/src/helpers/filetreeUtils.js
+++ b/src/helpers/filetreeUtils.js
@@ -91,7 +91,7 @@ const sortTree = (unsorted, navigationOrder, currentPath) => {
 };
 
 function getPermalinkMeta(note, key) {
-  let permalink = "/";
+  let permalink = note.url || "/";
   let parts = note.filePathStem.split("/");
   let name = parts[parts.length - 1];
   let noteIcon = process.env.NOTE_ICON_DEFAULT;


### PR DESCRIPTION
## Why
Nested notes could get wrong links: wikilink targets slugified the whole path as one string (breaking folder structure), and the filetree fell back to `/` when frontmatter had no `permalink`. Links and nav should follow each note’s real URL path.

## Summary
- Slugify each path segment when building wikilink permalinks (`notePathToPermalink`)
- Default filetree permalinks to `note.url` when frontmatter `permalink` is absent

## Test plan
- [ ] `npm test`
- [ ] Verify nested note links resolve correctly in content and filetree navigation