### PR TITLE
refactor: extract taggify and skip tags in protected HTML blocks

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -27,7 +27,7 @@ const htmlMinifier = require("html-minifier-terser");
 const pluginRss = require("@11ty/eleventy-plugin-rss");
 
 const { headerToId, namedHeadingsFilter } = require("./src/helpers/utils");
-const { tagRegex, taggify, extractSearchableTags } = require("./src/helpers/tagUtils");
+const { tagRegex, taggify, extractSearchableTags, withoutProtectedBlocks } = require("./src/helpers/tagUtils");
 const {
   userMarkdownSetup,
   userEleventySetup,
@@ -378,7 +378,7 @@ module.exports = function(eleventyConfig) {
   });
 
   eleventyConfig.addFilter("stripForSearch", function(content) {
-    return content
+    return withoutProtectedBlocks(content || "")
       .replace(/<[^>]*>/g, '')
       .replace(/\s+/g, ' ')
       .trim();

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -27,6 +27,7 @@ const htmlMinifier = require("html-minifier-terser");
 const pluginRss = require("@11ty/eleventy-plugin-rss");
 
 const { headerToId, namedHeadingsFilter } = require("./src/helpers/utils");
+const { tagRegex, taggify } = require("./src/helpers/tagUtils");
 const {
   userMarkdownSetup,
   userEleventySetup,
@@ -113,7 +114,6 @@ function getAnchorAttributes(filePath, linkTitle) {
   }
 }
 
-const tagRegex = /(^|\s|\>)(#[^\s!@#$%^&*()=+\.,\[{\]};:'"?><]+)(?!([^<]*>))/g;
 
 const markdownFileTypeRegex = /\.(md|markdown)$/i;
 const isMarkdownPage = (inputPath) => inputPath && inputPath.match(markdownFileTypeRegex);
@@ -374,12 +374,7 @@ module.exports = function(eleventyConfig) {
   });
 
   eleventyConfig.addFilter("taggify", function(str) {
-    return (
-      str &&
-      str.replace(tagRegex, function(match, precede, tag) {
-        return `${precede}<a class="tag" onclick="toggleTagSearch(this)" data-content="${tag}">${tag}</a>`;
-      })
-    );
+    return str && taggify(str);
   });
 
   eleventyConfig.addFilter("stripForSearch", function(content) {

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -27,7 +27,7 @@ const htmlMinifier = require("html-minifier-terser");
 const pluginRss = require("@11ty/eleventy-plugin-rss");
 
 const { headerToId, namedHeadingsFilter } = require("./src/helpers/utils");
-const { tagRegex, taggify } = require("./src/helpers/tagUtils");
+const { tagRegex, taggify, extractSearchableTags } = require("./src/helpers/tagUtils");
 const {
   userMarkdownSetup,
   userEleventySetup,
@@ -385,20 +385,9 @@ module.exports = function(eleventyConfig) {
   });
 
   eleventyConfig.addFilter("searchableTags", function(str) {
-    let tags;
-    let match = str && str.match(tagRegex);
-    if (match) {
-      tags = match
-        .map((m) => {
-          return `"${m.split("#")[1]}"`;
-        })
-        .join(", ");
-    }
-    if (tags) {
-      return `${tags},`;
-    } else {
-      return "";
-    }
+    const tags = extractSearchableTags(str);
+    if (!tags.length) return "";
+    return tags.map((tag) => `"${tag}"`).join(", ") + ",";
   });
 
   eleventyConfig.addFilter("hideDataview", function(str) {

--- a/src/helpers/__tests__/tagUtils.test.js
+++ b/src/helpers/__tests__/tagUtils.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { taggify, extractSearchableTags } from "../tagUtils.js";
+import { taggify, extractSearchableTags, withoutProtectedBlocks } from "../tagUtils.js";
 
 describe("taggify", () => {
   it("preserves MathJax styles while linking page tags", () => {
@@ -22,5 +22,19 @@ describe("extractSearchableTags", () => {
 
   it("dedupes repeated tags", () => {
     expect(extractSearchableTags("<p>#math #math</p>")).toEqual(["math"]);
+  });
+});
+
+describe("withoutProtectedBlocks", () => {
+  it("removes MathJax style CSS so it cannot leak into search snippets", () => {
+    const content =
+      'Integral Test <style>#mjx-61a4a83{ display:contents; }</style> Summary #calculus';
+    const stripped = withoutProtectedBlocks(content)
+      .replace(/<[^>]*>/g, "")
+      .replace(/\s+/g, " ")
+      .trim();
+
+    expect(stripped).toBe("Integral Test Summary #calculus");
+    expect(stripped).not.toContain("mjx");
   });
 });

--- a/src/helpers/__tests__/tagUtils.test.js
+++ b/src/helpers/__tests__/tagUtils.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { taggify } from "../tagUtils.js";
+import { taggify, extractSearchableTags } from "../tagUtils.js";
 
 describe("taggify", () => {
   it("preserves MathJax styles while linking page tags", () => {
@@ -9,5 +9,18 @@ describe("taggify", () => {
     expect(taggify(content)).toBe(
       '<style>mjx-tip { border: 1px solid #888; }</style><p><a class="tag" href="javascript:void(0);" onclick="toggleTagSearch(this)">#statistics</a></p>',
     );
+  });
+});
+
+describe("extractSearchableTags", () => {
+  it("ignores hex colors inside style blocks and keeps page tags", () => {
+    const content =
+      '<style>mjx-tip { border: 1px solid #888; background-color: #F8F8F8; }</style><p>#calculus #series</p>';
+
+    expect(extractSearchableTags(content)).toEqual(["calculus", "series"]);
+  });
+
+  it("dedupes repeated tags", () => {
+    expect(extractSearchableTags("<p>#math #math</p>")).toEqual(["math"]);
   });
 });

--- a/src/helpers/__tests__/tagUtils.test.js
+++ b/src/helpers/__tests__/tagUtils.test.js
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { taggify } from "../tagUtils.js";
+
+describe("taggify", () => {
+  it("preserves MathJax styles while linking page tags", () => {
+    const content =
+      '<style>mjx-tip { border: 1px solid #888; }</style><p>#statistics</p>';
+
+    expect(taggify(content)).toBe(
+      '<style>mjx-tip { border: 1px solid #888; }</style><p><a class="tag" href="javascript:void(0);" onclick="toggleTagSearch(this)">#statistics</a></p>',
+    );
+  });
+});

--- a/src/helpers/tagUtils.js
+++ b/src/helpers/tagUtils.js
@@ -1,0 +1,26 @@
+const tagRegex = /(^|\s|\>)(#[^\s!@#$%^&*()=+\.,\[{\]};:'"?><]+)(?!([^<]*>))/g;
+const protectedBlockRegex = /<(code|pre|script|style)\b[^>]*>[\s\S]*?<\/\1>/gi;
+
+function linkTags(content) {
+  return content.replace(tagRegex, (match, precede, tag) => {
+    return `${precede}<a class="tag" href="javascript:void(0);" onclick="toggleTagSearch(this)">${tag}</a>`;
+  });
+}
+
+function taggify(content) {
+  let result = "";
+  let previousEnd = 0;
+  let match;
+
+  protectedBlockRegex.lastIndex = 0;
+  while ((match = protectedBlockRegex.exec(content)) !== null) {
+    result += linkTags(content.slice(previousEnd, match.index));
+    result += match[0];
+    previousEnd = match.index + match[0].length;
+  }
+
+  return result + linkTags(content.slice(previousEnd));
+}
+
+exports.tagRegex = tagRegex;
+exports.taggify = taggify;

--- a/src/helpers/tagUtils.js
+++ b/src/helpers/tagUtils.js
@@ -1,6 +1,11 @@
 const tagRegex = /(^|\s|\>)(#[^\s!@#$%^&*()=+\.,\[{\]};:'"?><]+)(?!([^<]*>))/g;
 const protectedBlockRegex = /<(code|pre|script|style)\b[^>]*>[\s\S]*?<\/\1>/gi;
 
+function withoutProtectedBlocks(content) {
+  if (!content) return content;
+  return content.replace(protectedBlockRegex, " ");
+}
+
 function linkTags(content) {
   return content.replace(tagRegex, (match, precede, tag) => {
     return `${precede}<a class="tag" href="javascript:void(0);" onclick="toggleTagSearch(this)">${tag}</a>`;
@@ -22,5 +27,29 @@ function taggify(content) {
   return result + linkTags(content.slice(previousEnd));
 }
 
+/**
+ * Extract unique #tags from HTML-ish content, ignoring protected blocks
+ * (code/pre/script/style) so MathJax CSS hex colors are not treated as tags.
+ */
+function extractSearchableTags(content) {
+  if (!content) return [];
+
+  const searchable = withoutProtectedBlocks(content);
+  const matches = searchable.match(tagRegex) || [];
+  const tags = [];
+  const seen = new Set();
+
+  for (const match of matches) {
+    const tag = match.split("#")[1];
+    if (!tag || seen.has(tag)) continue;
+    seen.add(tag);
+    tags.push(tag);
+  }
+
+  return tags;
+}
+
 exports.tagRegex = tagRegex;
 exports.taggify = taggify;
+exports.withoutProtectedBlocks = withoutProtectedBlocks;
+exports.extractSearchableTags = extractSearchableTags;


### PR DESCRIPTION
## Why
`#tag` linkification and search indexing could treat hashtags inside protected HTML as real tags — especially MathJax `<style>` blocks with CSS colors like `#888`. That corrupts rendered styles and floods search with fake tags on math-heavy vaults. Separately, `stripForSearch` left the *text* of those style blocks in snippets (`#mjx-…{ display:contents; …}`).

<img width="1532" height="850" alt="image" src="https://github.com/user-attachments/assets/ba43ae5b-c7c5-41e3-b408-38c1ede0d039" />


## Summary
- Extract `taggify` into `src/helpers/tagUtils.js`
- Skip tag linkification inside `<code>`, `<pre>`, `<script>`, and `<style>` blocks
- Make `searchableTags` use the same protected-block stripping (and dedupe)
- Make `stripForSearch` drop protected blocks before stripping tags so MathJax CSS does not appear in search snippets

## Test plan
- [x] `TZ=UTC npx vitest run src/helpers/__tests__/tagUtils.test.js`
- [x] Verify page tags still link while MathJax/style blocks stay untouched
- [x] Rebuild a math-heavy vault and confirm search no longer lists hex colors as tags or `#mjx-…` CSS in snippets

Result ([my vault](https://statistics-digital-garden.vercel.app/)):
<img width="1526" height="929" alt="image" src="https://github.com/user-attachments/assets/09720e69-b92e-436c-ac48-3ce7f87bb203" />
