### PR TITLE
fix: base card cover thumbnails — note.* syntax and wikilink/markdown-link cover values

### DIFF
--- a/src/helpers/bases-engine/__tests__/views.test.js
+++ b/src/helpers/bases-engine/__tests__/views.test.js
@@ -83,6 +83,23 @@ describe("renderViews", () => {
 			expect(result).toContain("<th>Year</th>");
 		});
 
+		it("resolves note.-prefixed columns (Obsidian-generated syntax)", () => {
+			const result = renderViews(
+				makeQueryResult([
+					singleView(
+						{
+							type: "table",
+							name: "My Table",
+							order: ["file.name", "note.author"],
+						},
+						basicRows,
+					),
+				]),
+			);
+			expect(result).toContain("<th>Author</th>");
+			expect(result).toContain("F. Scott Fitzgerald");
+		});
+
 		it("renders summary bar when computedSummaries has values", () => {
 			const result = renderViews(
 				makeQueryResult([
@@ -440,6 +457,141 @@ describe("renderViews", () => {
 			);
 			expect(result).toContain("object-fit: contain");
 			expect(result).toContain("aspect-ratio: 2");
+		});
+
+		it("resolves note.-prefixed image field (Obsidian-generated syntax)", () => {
+			const rows = [
+				makeRow("Test", "/notes/test/", {
+					cover: "/images/cover.jpg",
+				}),
+			];
+			const result = renderViews(
+				makeQueryResult([
+					singleView(
+						{
+							type: "cards",
+							name: "Cards",
+							image: "note.cover",
+							order: ["file.name"],
+						},
+						rows,
+					),
+				]),
+			);
+			expect(result).toContain("<img");
+			expect(result).toContain("/images/cover.jpg");
+		});
+
+		it("resolves wikilink image values to published image URLs", () => {
+			const rows = [
+				makeRow("Test", "/notes/test/", {
+					cover: "[[A Assets/cover.png]]",
+				}),
+			];
+			const result = renderViews(
+				makeQueryResult([
+					singleView(
+						{
+							type: "cards",
+							name: "Cards",
+							image: "cover",
+							order: ["file.name"],
+						},
+						rows,
+					),
+				]),
+			);
+			expect(result).toContain('src="/img/user/A Assets/cover.png"');
+		});
+
+		it("resolves embed wikilinks with alias to published image URLs", () => {
+			const rows = [
+				makeRow("Test", "/notes/test/", {
+					cover: "![[cover.png|300]]",
+				}),
+			];
+			const result = renderViews(
+				makeQueryResult([
+					singleView(
+						{
+							type: "cards",
+							name: "Cards",
+							image: "cover",
+							order: ["file.name"],
+						},
+						rows,
+					),
+				]),
+			);
+			expect(result).toContain('src="/img/user/cover.png"');
+		});
+
+		it("resolves markdown-link image values produced by older plugin exports", () => {
+			const rows = [
+				makeRow("Test", "/notes/test/", {
+					cover: "[A Assets/travolta.png](/img/user/A%20Assets/travolta.png)",
+				}),
+			];
+			const result = renderViews(
+				makeQueryResult([
+					singleView(
+						{
+							type: "cards",
+							name: "Cards",
+							image: "cover",
+							order: ["file.name"],
+						},
+						rows,
+					),
+				]),
+			);
+			expect(result).toContain(
+				'src="/img/user/A%20Assets/travolta.png"',
+			);
+		});
+
+		it("resolves embed markdown-link image values produced by older plugin exports", () => {
+			const rows = [
+				makeRow("Test", "/notes/test/", {
+					cover: "![cover](/img/user/cover.png)",
+				}),
+			];
+			const result = renderViews(
+				makeQueryResult([
+					singleView(
+						{
+							type: "cards",
+							name: "Cards",
+							image: "cover",
+							order: ["file.name"],
+						},
+						rows,
+					),
+				]),
+			);
+			expect(result).toContain('src="/img/user/cover.png"');
+		});
+
+		it("leaves external image URLs untouched", () => {
+			const rows = [
+				makeRow("Test", "/notes/test/", {
+					cover: "https://example.com/cover.png",
+				}),
+			];
+			const result = renderViews(
+				makeQueryResult([
+					singleView(
+						{
+							type: "cards",
+							name: "Cards",
+							image: "cover",
+							order: ["file.name"],
+						},
+						rows,
+					),
+				]),
+			);
+			expect(result).toContain('src="https://example.com/cover.png"');
 		});
 	});
 

--- a/src/helpers/bases-engine/views.js
+++ b/src/helpers/bases-engine/views.js
@@ -96,10 +96,11 @@ function getDisplayName(column, properties) {
 
 	if (column === "file.name") return "Name";
 
-	// Strip prefixes: formula.x → x, file.folder → folder
+	// Strip prefixes: formula.x → x, file.folder → folder, note.x → x
 	let name = column;
 	if (name.startsWith("formula.")) name = name.slice(8);
 	if (name.startsWith("file.")) name = name.slice(5);
+	if (name.startsWith("note.")) name = name.slice(5);
 
 	// Capitalize first letter
 	return name.charAt(0).toUpperCase() + name.slice(1);
@@ -118,6 +119,11 @@ function getFileName(row) {
  * Get a cell value from a row for a given column.
  */
 function getCellValue(row, column) {
+	// Obsidian writes user-property references as note.x in .base files
+	if (column.startsWith("note.")) {
+		column = column.slice(5);
+	}
+
 	if (column === "file.name") {
 		return getFileName(row);
 	}
@@ -345,6 +351,33 @@ function renderCards(view, properties) {
 	return buildCardsGrid(rows, columns, cardSize, imageField, imageFit, imageAspectRatio, properties);
 }
 
+/**
+ * Resolve a frontmatter image value to a URL on the published site.
+ * Handles wikilinks ([[path]], ![[path|alias]]), markdown links
+ * ([label](url), as produced when the plugin's link conversion touched
+ * the value), vault-relative paths (rewritten to /img/user/), and
+ * absolute/external URLs (left as-is).
+ */
+function resolveImageSource(imgValue) {
+	let src = String(imgValue).trim();
+
+	const wikilink = src.match(/^!?\[\[([^\]]+)\]\]$/);
+	if (wikilink) {
+		src = wikilink[1].split("|")[0].split("#")[0].trim();
+	}
+
+	const markdownLink = src.match(/^!?\[[^\]]*\]\(([^)]+)\)$/);
+	if (markdownLink) {
+		src = markdownLink[1].trim();
+	}
+
+	if (!src.startsWith("http") && !src.startsWith("/")) {
+		src = "/img/user/" + src;
+	}
+
+	return src;
+}
+
 function buildCardsGrid(rows, columns, cardSize, imageField, imageFit, imageAspectRatio, properties) {
 	let html = `<div class="obsidian-base-cards" style="grid-template-columns: repeat(auto-fill, minmax(${cardSize}px, 1fr));">`;
 
@@ -353,14 +386,10 @@ function buildCardsGrid(rows, columns, cardSize, imageField, imageFit, imageAspe
 
 		// Image section
 		if (imageField) {
-			let imgValue = getCellValue(row, imageField);
+			const imgValue = getCellValue(row, imageField);
 			if (imgValue) {
-				imgValue = String(imgValue);
-				// Resolve vault image paths to published URLs
-				if (!imgValue.startsWith("http") && !imgValue.startsWith("/")) {
-					imgValue = "/img/user/" + imgValue;
-				}
-				html += `<div class="obsidian-base-card-image"><img src="${escapeHtml(imgValue)}" style="object-fit: ${escapeHtml(imageFit)}; aspect-ratio: ${escapeHtml(String(imageAspectRatio))};" loading="lazy" /></div>`;
+				const imgSrc = resolveImageSource(imgValue);
+				html += `<div class="obsidian-base-card-image"><img src="${escapeHtml(imgSrc)}" style="object-fit: ${escapeHtml(imageFit)}; aspect-ratio: ${escapeHtml(String(imageAspectRatio))};" loading="lazy" /></div>`;
 			}
 		}
 


### PR DESCRIPTION
## Summary

Cards views in published bases rendered no thumbnails (or broken ones) for every configuration Obsidian's UI actually produces:

- `image: note.cover` — the syntax Obsidian writes into `.base` files — was looked up as the literal metadata key `"note.cover"`, so the image block was silently skipped. `getCellValue` and `getDisplayName` now strip the `note.` prefix, matching what the expression evaluator already did for filters. This also fixes `note.`-prefixed columns in table/cards `order`.
- Wikilink cover values (`[[cover.png]]`, `![[cover.png|300]]` — what Obsidian's image-property picker stores) rendered as broken `/img/user/[[...]]` URLs. The new `resolveImageSource` helper unwraps them.
- Markdown-link cover values (`[label](/img/user/...)`) are also resolved — older plugin versions' link conversion rewrote frontmatter wikilinks into this shape, so gardens published with those versions get working thumbnails from this template update alone, no re-publish needed.

External URLs and absolute paths pass through untouched.

## Test plan

- 8 new vitest cases covering: `note.`-prefixed image fields and table columns, wikilink and embed-with-alias cover values, markdown-link and embed-markdown-link values, and external URLs staying untouched. Suite: 241/241.
- Verified end-to-end against a built site with the test vault's `B Bases` QA notes (wikilink, plain-path, and external covers × three view syntaxes): all nine thumbnails render, local ones picked up by the image-optimization transform.

Companion PR on the plugin side: oleeskild/obsidian-digital-garden#808 (stops mangling frontmatter and publishes wikilink-referenced cover images).