### PR TITLE
fix: don't fail the build on images sharp can't decode

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -34,6 +34,7 @@ const {
 const { basesPlugin } = require("./src/helpers/basesPlugin");
 
 const Image = require("@11ty/eleventy-img");
+const { isTransformableImage } = require("./src/helpers/imageFormat.js");
 function transformImage(src, cls, alt, sizes, widths = ["500", "700", "auto"]) {
   let options = {
     widths: widths,
@@ -42,8 +43,12 @@ function transformImage(src, cls, alt, sizes, widths = ["500", "700", "auto"]) {
     urlPath: "/img/optimized",
   };
 
-  // generate images, while this is async we don’t wait
-  Image(src, options);
+  // Generate images; async, but we don't wait for it. A rejection here
+  // (e.g. a corrupt file) must not become an unhandled rejection, which
+  // would fail the whole build.
+  Image(src, options).catch((err) => {
+    console.warn(`[image] Skipping optimization of ${src}: ${err.message}`);
+  });
   let metadata = Image.statsSync(src, options);
   return metadata;
 }
@@ -558,6 +563,12 @@ module.exports = function(eleventyConfig) {
     for (const imageTag of parsed.querySelectorAll(".cm-s-obsidian img")) {
       const src = imageTag.getAttribute("src");
       if (src && src.startsWith("/") && !src.endsWith(".svg")) {
+        // Files whose content sharp can't decode (e.g. HEIC renamed to
+        // .jpg) keep their original <img> tag instead of a <picture>
+        // pointing at optimized files that will never exist.
+        if (!isTransformableImage("./src/site" + decodeURI(src))) {
+          continue;
+        }
         const cls = imageTag.classList.value;
         const alt = imageTag.getAttribute("alt");
         const width = imageTag.getAttribute("width") || '';

--- a/plugin-info.json
+++ b/plugin-info.json
@@ -24,6 +24,7 @@
         "src/site/img/tree-3.svg",
         "src/helpers/userUtils.js",
         "src/helpers/userSetup.js",
+        "src/helpers/imageFormat.js",
         "vercel.json",
         "netlify.toml",
         "src/site/_includes/layouts/random.njk",

--- a/src/helpers/imageFormat.js
+++ b/src/helpers/imageFormat.js
@@ -1,0 +1,58 @@
+const fs = require("fs");
+
+/**
+ * Check whether a file's actual content is an image format the sharp-based
+ * optimization pipeline can decode, by sniffing magic bytes. Extensions
+ * lie — e.g. iPhone HEIC photos renamed to .jpg — and feeding sharp an
+ * undecodable file fails the whole Eleventy build via an unhandled
+ * rejection. Unknown or unreadable files return false so the caller can
+ * leave the original <img> untouched.
+ */
+function isTransformableImage(filePath) {
+	let header;
+
+	try {
+		const fd = fs.openSync(filePath, "r");
+		header = Buffer.alloc(16);
+		fs.readSync(fd, header, 0, 16, 0);
+		fs.closeSync(fd);
+	} catch {
+		return false;
+	}
+
+	// JPEG
+	if (header[0] === 0xff && header[1] === 0xd8 && header[2] === 0xff) {
+		return true;
+	}
+
+	// PNG
+	if (header.subarray(0, 8).equals(Buffer.from("\x89PNG\r\n\x1a\n", "latin1"))) {
+		return true;
+	}
+
+	// GIF87a / GIF89a
+	const ascii = header.toString("latin1");
+	if (ascii.startsWith("GIF87a") || ascii.startsWith("GIF89a")) {
+		return true;
+	}
+
+	// WebP: RIFF....WEBP
+	if (ascii.startsWith("RIFF") && ascii.slice(8, 12) === "WEBP") {
+		return true;
+	}
+
+	// TIFF (also the container some raw formats use)
+	if (ascii.startsWith("II*\x00") || ascii.startsWith("MM\x00*")) {
+		return true;
+	}
+
+	// AVIF: ISO-BMFF ftyp box with an avif brand — sharp decodes these.
+	// Other ftyp brands (heic, heix, mif1…) are HEIC/HEIF: not decodable.
+	if (ascii.slice(4, 8) === "ftyp") {
+		return ascii.slice(8, 12) === "avif";
+	}
+
+	return false;
+}
+
+module.exports = { isTransformableImage };

--- a/src/helpers/imageFormat.test.js
+++ b/src/helpers/imageFormat.test.js
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { isTransformableImage } from "./imageFormat.js";
+
+const writeTemp = (name, bytes) => {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "img-format-"));
+	const file = path.join(dir, name);
+	fs.writeFileSync(file, Buffer.from(bytes));
+	return file;
+};
+
+describe("isTransformableImage", () => {
+	it("accepts a JPEG regardless of extension", () => {
+		expect(
+			isTransformableImage(writeTemp("photo.jpg", [0xff, 0xd8, 0xff, 0xe0])),
+		).toBe(true);
+	});
+
+	it("accepts a PNG", () => {
+		expect(
+			isTransformableImage(
+				writeTemp("img.png", [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+			),
+		).toBe(true);
+	});
+
+	it("accepts a WebP", () => {
+		const riff = [...Buffer.from("RIFF"), 0, 0, 0, 0, ...Buffer.from("WEBP")];
+		expect(isTransformableImage(writeTemp("img.webp", riff))).toBe(true);
+	});
+
+	it("accepts a GIF", () => {
+		expect(
+			isTransformableImage(writeTemp("img.gif", Buffer.from("GIF89a"))),
+		).toBe(true);
+	});
+
+	it("rejects a HEIC file renamed to .jpg", () => {
+		// iPhone photos: 4-byte box size, then "ftypheic"
+		const heic = [0, 0, 0, 24, ...Buffer.from("ftypheic"), 0, 0, 0, 0];
+		expect(isTransformableImage(writeTemp("EyetotheEar.jpg", heic))).toBe(
+			false,
+		);
+	});
+
+	it("rejects arbitrary non-image bytes", () => {
+		expect(
+			isTransformableImage(
+				writeTemp("fake.jpg", Buffer.from("hello, not an image")),
+			),
+		).toBe(false);
+	});
+
+	it("rejects a missing file", () => {
+		expect(isTransformableImage("/nonexistent/img.jpg")).toBe(false);
+	});
+});


### PR DESCRIPTION
## Problem

Follow-up to #392, from the same garden: the build now dies with

```
[11ty] Unhandled rejection in promise:
[11ty] ...EyetotheEar.jpg: bad seek to 34041
[11ty] heif: Invalid input: Unspecified: Bitstream not supported by this decoder
```

`EyetotheEar.jpg` is an iPhone **HEIC photo renamed to .jpg**. Before #392 the cover path 404ed so the optimizer never opened the file; now that covers resolve, sharp tries to decode it. `transformImage`'s `Image(src, options)` call is fire-and-forget — its dropped promise rejects, and that unhandled rejection fails the entire build. The existing try/catch only guards the sync `statsSync` call, so the "fault tolerant" intent never covered this path. Any garden with one mislabeled image was one body-embed away from the same crash.

## Fix

- New `src/helpers/imageFormat.js`: `isTransformableImage` sniffs magic bytes (JPEG/PNG/GIF/WebP/TIFF/AVIF pass; HEIC/HEIF `ftyp` brands and unrecognized content fail). The picture transform skips non-decodable files, keeping the original `<img>` tag instead of emitting a `<picture>` pointing at optimized files that will never exist.
- The `Image()` call gets a `.catch` logging a warning — any other decode failure now degrades to an unoptimized image instead of a dead build.
- Registered the new helper in `plugin-info.json` `filesToAdd` so site updates deliver it alongside the modified `.eleventy.js`.

Note: the affected image still won't display in browsers (they can't decode HEIC either) — the file itself needs re-exporting as a real JPEG. This fix just stops one bad file from taking down the whole site build.

## Testing

- 7 new unit tests for the format sniffer; 261 total pass.
- E2E reproduction: a crafted `ftypheic` file named `.jpg`, embedded in a QA note, run with `USE_FULL_RESOLUTION_IMAGES=false` — build fails with the exact reported error before the fix, succeeds after with the original img tag preserved and other images still optimized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TFUucReuWzHi8VCKMovneB