### PR TITLE
chore: update vulnerable dependencies via npm audit fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
         "": {
             "name": "web",
             "version": "1.0.0",
-            "license": "ISC",
+            "license": "MIT",
             "dependencies": {
                 "@11ty/eleventy-img": "^4.0.2",
                 "@sindresorhus/slugify": "^1.1.0",
@@ -306,10 +306,20 @@
             }
         },
         "node_modules/@11ty/eleventy/node_modules/js-yaml": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-            "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+            "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
             "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/puzrin"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/nodeca"
+                }
+            ],
             "license": "MIT",
             "dependencies": {
                 "argparse": "^2.0.1"
@@ -319,9 +329,9 @@
             }
         },
         "node_modules/@11ty/eleventy/node_modules/picomatch": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-            "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+            "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -377,21 +387,21 @@
             }
         },
         "node_modules/@emnapi/core": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.1.tgz",
-            "integrity": "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+            "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
             "dev": true,
             "license": "MIT",
             "optional": true,
             "dependencies": {
-                "@emnapi/wasi-threads": "1.2.0",
+                "@emnapi/wasi-threads": "1.2.2",
                 "tslib": "^2.4.0"
             }
         },
         "node_modules/@emnapi/runtime": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.1.tgz",
-            "integrity": "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==",
+            "version": "1.11.3",
+            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+            "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
             "license": "MIT",
             "optional": true,
             "dependencies": {
@@ -399,9 +409,9 @@
             }
         },
         "node_modules/@emnapi/wasi-threads": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",
-            "integrity": "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==",
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+            "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
             "dev": true,
             "license": "MIT",
             "optional": true,
@@ -417,431 +427,361 @@
             "license": "MIT"
         },
         "node_modules/@img/sharp-darwin-arm64": {
-            "version": "0.33.4",
-            "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.4.tgz",
-            "integrity": "sha512-p0suNqXufJs9t3RqLBO6vvrgr5OhgbWp76s5gTRvdmxmuv9E1rcaqGUsl3l4mKVmXPkTkTErXediAui4x+8PSA==",
+            "version": "0.33.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.5.tgz",
+            "integrity": "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==",
             "cpu": [
                 "arm64"
             ],
+            "license": "Apache-2.0",
             "optional": true,
             "os": [
                 "darwin"
             ],
             "engines": {
-                "glibc": ">=2.26",
-                "node": "^18.17.0 || ^20.3.0 || >=21.0.0",
-                "npm": ">=9.6.5",
-                "pnpm": ">=7.1.0",
-                "yarn": ">=3.2.0"
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
             },
             "funding": {
                 "url": "https://opencollective.com/libvips"
             },
             "optionalDependencies": {
-                "@img/sharp-libvips-darwin-arm64": "1.0.2"
+                "@img/sharp-libvips-darwin-arm64": "1.0.4"
             }
         },
         "node_modules/@img/sharp-darwin-x64": {
-            "version": "0.33.4",
-            "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.4.tgz",
-            "integrity": "sha512-0l7yRObwtTi82Z6ebVI2PnHT8EB2NxBgpK2MiKJZJ7cz32R4lxd001ecMhzzsZig3Yv9oclvqqdV93jo9hy+Dw==",
+            "version": "0.33.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.5.tgz",
+            "integrity": "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==",
             "cpu": [
                 "x64"
             ],
+            "license": "Apache-2.0",
             "optional": true,
             "os": [
                 "darwin"
             ],
             "engines": {
-                "glibc": ">=2.26",
-                "node": "^18.17.0 || ^20.3.0 || >=21.0.0",
-                "npm": ">=9.6.5",
-                "pnpm": ">=7.1.0",
-                "yarn": ">=3.2.0"
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
             },
             "funding": {
                 "url": "https://opencollective.com/libvips"
             },
             "optionalDependencies": {
-                "@img/sharp-libvips-darwin-x64": "1.0.2"
+                "@img/sharp-libvips-darwin-x64": "1.0.4"
             }
         },
         "node_modules/@img/sharp-libvips-darwin-arm64": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.0.2.tgz",
-            "integrity": "sha512-tcK/41Rq8IKlSaKRCCAuuY3lDJjQnYIW1UXU1kxcEKrfL8WR7N6+rzNoOxoQRJWTAECuKwgAHnPvqXGN8XfkHA==",
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.0.4.tgz",
+            "integrity": "sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==",
             "cpu": [
                 "arm64"
             ],
+            "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
                 "darwin"
             ],
-            "engines": {
-                "macos": ">=11",
-                "npm": ">=9.6.5",
-                "pnpm": ">=7.1.0",
-                "yarn": ">=3.2.0"
-            },
             "funding": {
                 "url": "https://opencollective.com/libvips"
             }
         },
         "node_modules/@img/sharp-libvips-darwin-x64": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.2.tgz",
-            "integrity": "sha512-Ofw+7oaWa0HiiMiKWqqaZbaYV3/UGL2wAPeLuJTx+9cXpCRdvQhCLG0IH8YGwM0yGWGLpsF4Su9vM1o6aer+Fw==",
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.4.tgz",
+            "integrity": "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==",
             "cpu": [
                 "x64"
             ],
+            "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
                 "darwin"
             ],
-            "engines": {
-                "macos": ">=10.13",
-                "npm": ">=9.6.5",
-                "pnpm": ">=7.1.0",
-                "yarn": ">=3.2.0"
-            },
             "funding": {
                 "url": "https://opencollective.com/libvips"
             }
         },
         "node_modules/@img/sharp-libvips-linux-arm": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.2.tgz",
-            "integrity": "sha512-iLWCvrKgeFoglQxdEwzu1eQV04o8YeYGFXtfWU26Zr2wWT3q3MTzC+QTCO3ZQfWd3doKHT4Pm2kRmLbupT+sZw==",
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.5.tgz",
+            "integrity": "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==",
             "cpu": [
                 "arm"
             ],
+            "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
                 "linux"
             ],
-            "engines": {
-                "glibc": ">=2.28",
-                "npm": ">=9.6.5",
-                "pnpm": ">=7.1.0",
-                "yarn": ">=3.2.0"
-            },
             "funding": {
                 "url": "https://opencollective.com/libvips"
             }
         },
         "node_modules/@img/sharp-libvips-linux-arm64": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.0.2.tgz",
-            "integrity": "sha512-x7kCt3N00ofFmmkkdshwj3vGPCnmiDh7Gwnd4nUwZln2YjqPxV1NlTyZOvoDWdKQVDL911487HOueBvrpflagw==",
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.0.4.tgz",
+            "integrity": "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==",
             "cpu": [
                 "arm64"
             ],
+            "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
                 "linux"
             ],
-            "engines": {
-                "glibc": ">=2.26",
-                "npm": ">=9.6.5",
-                "pnpm": ">=7.1.0",
-                "yarn": ">=3.2.0"
-            },
             "funding": {
                 "url": "https://opencollective.com/libvips"
             }
         },
         "node_modules/@img/sharp-libvips-linux-s390x": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.0.2.tgz",
-            "integrity": "sha512-cmhQ1J4qVhfmS6szYW7RT+gLJq9dH2i4maq+qyXayUSn9/3iY2ZeWpbAgSpSVbV2E1JUL2Gg7pwnYQ1h8rQIog==",
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.0.4.tgz",
+            "integrity": "sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==",
             "cpu": [
                 "s390x"
             ],
+            "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
                 "linux"
             ],
-            "engines": {
-                "glibc": ">=2.28",
-                "npm": ">=9.6.5",
-                "pnpm": ">=7.1.0",
-                "yarn": ">=3.2.0"
-            },
             "funding": {
                 "url": "https://opencollective.com/libvips"
             }
         },
         "node_modules/@img/sharp-libvips-linux-x64": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.2.tgz",
-            "integrity": "sha512-E441q4Qdb+7yuyiADVi5J+44x8ctlrqn8XgkDTwr4qPJzWkaHwD489iZ4nGDgcuya4iMN3ULV6NwbhRZJ9Z7SQ==",
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.4.tgz",
+            "integrity": "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==",
             "cpu": [
                 "x64"
             ],
+            "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
                 "linux"
             ],
-            "engines": {
-                "glibc": ">=2.26",
-                "npm": ">=9.6.5",
-                "pnpm": ">=7.1.0",
-                "yarn": ">=3.2.0"
-            },
             "funding": {
                 "url": "https://opencollective.com/libvips"
             }
         },
         "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.0.2.tgz",
-            "integrity": "sha512-3CAkndNpYUrlDqkCM5qhksfE+qSIREVpyoeHIU6jd48SJZViAmznoQQLAv4hVXF7xyUB9zf+G++e2v1ABjCbEQ==",
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.0.4.tgz",
+            "integrity": "sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==",
             "cpu": [
                 "arm64"
             ],
+            "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
                 "linux"
             ],
-            "engines": {
-                "musl": ">=1.2.2",
-                "npm": ">=9.6.5",
-                "pnpm": ">=7.1.0",
-                "yarn": ">=3.2.0"
-            },
             "funding": {
                 "url": "https://opencollective.com/libvips"
             }
         },
         "node_modules/@img/sharp-libvips-linuxmusl-x64": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.2.tgz",
-            "integrity": "sha512-VI94Q6khIHqHWNOh6LLdm9s2Ry4zdjWJwH56WoiJU7NTeDwyApdZZ8c+SADC8OH98KWNQXnE01UdJ9CSfZvwZw==",
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.4.tgz",
+            "integrity": "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==",
             "cpu": [
                 "x64"
             ],
+            "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
                 "linux"
             ],
-            "engines": {
-                "musl": ">=1.2.2",
-                "npm": ">=9.6.5",
-                "pnpm": ">=7.1.0",
-                "yarn": ">=3.2.0"
-            },
             "funding": {
                 "url": "https://opencollective.com/libvips"
             }
         },
         "node_modules/@img/sharp-linux-arm": {
-            "version": "0.33.4",
-            "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.4.tgz",
-            "integrity": "sha512-RUgBD1c0+gCYZGCCe6mMdTiOFS0Zc/XrN0fYd6hISIKcDUbAW5NtSQW9g/powkrXYm6Vzwd6y+fqmExDuCdHNQ==",
+            "version": "0.33.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.5.tgz",
+            "integrity": "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==",
             "cpu": [
                 "arm"
             ],
+            "license": "Apache-2.0",
             "optional": true,
             "os": [
                 "linux"
             ],
             "engines": {
-                "glibc": ">=2.28",
-                "node": "^18.17.0 || ^20.3.0 || >=21.0.0",
-                "npm": ">=9.6.5",
-                "pnpm": ">=7.1.0",
-                "yarn": ">=3.2.0"
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
             },
             "funding": {
                 "url": "https://opencollective.com/libvips"
             },
             "optionalDependencies": {
-                "@img/sharp-libvips-linux-arm": "1.0.2"
+                "@img/sharp-libvips-linux-arm": "1.0.5"
             }
         },
         "node_modules/@img/sharp-linux-arm64": {
-            "version": "0.33.4",
-            "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.4.tgz",
-            "integrity": "sha512-2800clwVg1ZQtxwSoTlHvtm9ObgAax7V6MTAB/hDT945Tfyy3hVkmiHpeLPCKYqYR1Gcmv1uDZ3a4OFwkdBL7Q==",
+            "version": "0.33.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.5.tgz",
+            "integrity": "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==",
             "cpu": [
                 "arm64"
             ],
+            "license": "Apache-2.0",
             "optional": true,
             "os": [
                 "linux"
             ],
             "engines": {
-                "glibc": ">=2.26",
-                "node": "^18.17.0 || ^20.3.0 || >=21.0.0",
-                "npm": ">=9.6.5",
-                "pnpm": ">=7.1.0",
-                "yarn": ">=3.2.0"
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
             },
             "funding": {
                 "url": "https://opencollective.com/libvips"
             },
             "optionalDependencies": {
-                "@img/sharp-libvips-linux-arm64": "1.0.2"
+                "@img/sharp-libvips-linux-arm64": "1.0.4"
             }
         },
         "node_modules/@img/sharp-linux-s390x": {
-            "version": "0.33.4",
-            "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.33.4.tgz",
-            "integrity": "sha512-h3RAL3siQoyzSoH36tUeS0PDmb5wINKGYzcLB5C6DIiAn2F3udeFAum+gj8IbA/82+8RGCTn7XW8WTFnqag4tQ==",
+            "version": "0.33.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.33.5.tgz",
+            "integrity": "sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==",
             "cpu": [
                 "s390x"
             ],
+            "license": "Apache-2.0",
             "optional": true,
             "os": [
                 "linux"
             ],
             "engines": {
-                "glibc": ">=2.31",
-                "node": "^18.17.0 || ^20.3.0 || >=21.0.0",
-                "npm": ">=9.6.5",
-                "pnpm": ">=7.1.0",
-                "yarn": ">=3.2.0"
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
             },
             "funding": {
                 "url": "https://opencollective.com/libvips"
             },
             "optionalDependencies": {
-                "@img/sharp-libvips-linux-s390x": "1.0.2"
+                "@img/sharp-libvips-linux-s390x": "1.0.4"
             }
         },
         "node_modules/@img/sharp-linux-x64": {
-            "version": "0.33.4",
-            "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.4.tgz",
-            "integrity": "sha512-GoR++s0XW9DGVi8SUGQ/U4AeIzLdNjHka6jidVwapQ/JebGVQIpi52OdyxCNVRE++n1FCLzjDovJNozif7w/Aw==",
+            "version": "0.33.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.5.tgz",
+            "integrity": "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==",
             "cpu": [
                 "x64"
             ],
+            "license": "Apache-2.0",
             "optional": true,
             "os": [
                 "linux"
             ],
             "engines": {
-                "glibc": ">=2.26",
-                "node": "^18.17.0 || ^20.3.0 || >=21.0.0",
-                "npm": ">=9.6.5",
-                "pnpm": ">=7.1.0",
-                "yarn": ">=3.2.0"
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
             },
             "funding": {
                 "url": "https://opencollective.com/libvips"
             },
             "optionalDependencies": {
-                "@img/sharp-libvips-linux-x64": "1.0.2"
+                "@img/sharp-libvips-linux-x64": "1.0.4"
             }
         },
         "node_modules/@img/sharp-linuxmusl-arm64": {
-            "version": "0.33.4",
-            "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.4.tgz",
-            "integrity": "sha512-nhr1yC3BlVrKDTl6cO12gTpXMl4ITBUZieehFvMntlCXFzH2bvKG76tBL2Y/OqhupZt81pR7R+Q5YhJxW0rGgQ==",
+            "version": "0.33.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.5.tgz",
+            "integrity": "sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==",
             "cpu": [
                 "arm64"
             ],
+            "license": "Apache-2.0",
             "optional": true,
             "os": [
                 "linux"
             ],
             "engines": {
-                "musl": ">=1.2.2",
-                "node": "^18.17.0 || ^20.3.0 || >=21.0.0",
-                "npm": ">=9.6.5",
-                "pnpm": ">=7.1.0",
-                "yarn": ">=3.2.0"
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
             },
             "funding": {
                 "url": "https://opencollective.com/libvips"
             },
             "optionalDependencies": {
-                "@img/sharp-libvips-linuxmusl-arm64": "1.0.2"
+                "@img/sharp-libvips-linuxmusl-arm64": "1.0.4"
             }
         },
         "node_modules/@img/sharp-linuxmusl-x64": {
-            "version": "0.33.4",
-            "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.4.tgz",
-            "integrity": "sha512-uCPTku0zwqDmZEOi4ILyGdmW76tH7dm8kKlOIV1XC5cLyJ71ENAAqarOHQh0RLfpIpbV5KOpXzdU6XkJtS0daw==",
+            "version": "0.33.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.5.tgz",
+            "integrity": "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==",
             "cpu": [
                 "x64"
             ],
+            "license": "Apache-2.0",
             "optional": true,
             "os": [
                 "linux"
             ],
             "engines": {
-                "musl": ">=1.2.2",
-                "node": "^18.17.0 || ^20.3.0 || >=21.0.0",
-                "npm": ">=9.6.5",
-                "pnpm": ">=7.1.0",
-                "yarn": ">=3.2.0"
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
             },
             "funding": {
                 "url": "https://opencollective.com/libvips"
             },
             "optionalDependencies": {
-                "@img/sharp-libvips-linuxmusl-x64": "1.0.2"
+                "@img/sharp-libvips-linuxmusl-x64": "1.0.4"
             }
         },
         "node_modules/@img/sharp-wasm32": {
-            "version": "0.33.4",
-            "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.33.4.tgz",
-            "integrity": "sha512-Bmmauh4sXUsUqkleQahpdNXKvo+wa1V9KhT2pDA4VJGKwnKMJXiSTGphn0gnJrlooda0QxCtXc6RX1XAU6hMnQ==",
+            "version": "0.33.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.33.5.tgz",
+            "integrity": "sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==",
             "cpu": [
                 "wasm32"
             ],
+            "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
             "optional": true,
             "dependencies": {
-                "@emnapi/runtime": "^1.1.1"
+                "@emnapi/runtime": "^1.2.0"
             },
             "engines": {
-                "node": "^18.17.0 || ^20.3.0 || >=21.0.0",
-                "npm": ">=9.6.5",
-                "pnpm": ">=7.1.0",
-                "yarn": ">=3.2.0"
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
             },
             "funding": {
                 "url": "https://opencollective.com/libvips"
             }
         },
         "node_modules/@img/sharp-win32-ia32": {
-            "version": "0.33.4",
-            "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.33.4.tgz",
-            "integrity": "sha512-99SJ91XzUhYHbx7uhK3+9Lf7+LjwMGQZMDlO/E/YVJ7Nc3lyDFZPGhjwiYdctoH2BOzW9+TnfqcaMKt0jHLdqw==",
+            "version": "0.33.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.33.5.tgz",
+            "integrity": "sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ==",
             "cpu": [
                 "ia32"
             ],
+            "license": "Apache-2.0 AND LGPL-3.0-or-later",
             "optional": true,
             "os": [
                 "win32"
             ],
             "engines": {
-                "node": "^18.17.0 || ^20.3.0 || >=21.0.0",
-                "npm": ">=9.6.5",
-                "pnpm": ">=7.1.0",
-                "yarn": ">=3.2.0"
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
             },
             "funding": {
                 "url": "https://opencollective.com/libvips"
             }
         },
         "node_modules/@img/sharp-win32-x64": {
-            "version": "0.33.4",
-            "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.4.tgz",
-            "integrity": "sha512-3QLocdTRVIrFNye5YocZl+KKpYKP+fksi1QhmOArgx7GyhIbQp/WrJRu176jm8IxromS7RIkzMiMINVdBtC8Aw==",
+            "version": "0.33.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.5.tgz",
+            "integrity": "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==",
             "cpu": [
                 "x64"
             ],
+            "license": "Apache-2.0 AND LGPL-3.0-or-later",
             "optional": true,
             "os": [
                 "win32"
             ],
             "engines": {
-                "node": "^18.17.0 || ^20.3.0 || >=21.0.0",
-                "npm": ">=9.6.5",
-                "pnpm": ">=7.1.0",
-                "yarn": ">=3.2.0"
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
             },
             "funding": {
                 "url": "https://opencollective.com/libvips"
@@ -923,26 +863,28 @@
             }
         },
         "node_modules/@napi-rs/wasm-runtime": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.1.tgz",
-            "integrity": "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==",
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+            "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
             "dev": true,
             "license": "MIT",
             "optional": true,
             "dependencies": {
-                "@emnapi/core": "^1.7.1",
-                "@emnapi/runtime": "^1.7.1",
-                "@tybys/wasm-util": "^0.10.1"
+                "@tybys/wasm-util": "^0.10.3"
             },
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/Brooooooklyn"
+            },
+            "peerDependencies": {
+                "@emnapi/core": "^1.7.1",
+                "@emnapi/runtime": "^1.7.1"
             }
         },
         "node_modules/@oxc-project/types": {
-            "version": "0.120.0",
-            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.120.0.tgz",
-            "integrity": "sha512-k1YNu55DuvAip/MGE1FTsIuU3FUCn6v/ujG9V7Nq5Df/kX2CWb13hhwD0lmJGMGqE+bE1MXvv9SZVnMzEXlWcg==",
+            "version": "0.139.0",
+            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+            "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
             "dev": true,
             "license": "MIT",
             "funding": {
@@ -959,9 +901,9 @@
             }
         },
         "node_modules/@rolldown/binding-android-arm64": {
-            "version": "1.0.0-rc.10",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.10.tgz",
-            "integrity": "sha512-jOHxwXhxmFKuXztiu1ORieJeTbx5vrTkcOkkkn2d35726+iwhrY1w/+nYY/AGgF12thg33qC3R1LMBF5tHTZHg==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+            "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
             "cpu": [
                 "arm64"
             ],
@@ -976,9 +918,9 @@
             }
         },
         "node_modules/@rolldown/binding-darwin-arm64": {
-            "version": "1.0.0-rc.10",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.10.tgz",
-            "integrity": "sha512-gED05Teg/vtTZbIJBc4VNMAxAFDUPkuO/rAIyyxZjTj1a1/s6z5TII/5yMGZ0uLRCifEtwUQn8OlYzuYc0m70w==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+            "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
             "cpu": [
                 "arm64"
             ],
@@ -993,9 +935,9 @@
             }
         },
         "node_modules/@rolldown/binding-darwin-x64": {
-            "version": "1.0.0-rc.10",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.10.tgz",
-            "integrity": "sha512-rI15NcM1mA48lqrIxVkHfAqcyFLcQwyXWThy+BQ5+mkKKPvSO26ir+ZDp36AgYoYVkqvMcdS8zOE6SeBsR9e8A==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+            "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
             "cpu": [
                 "x64"
             ],
@@ -1010,9 +952,9 @@
             }
         },
         "node_modules/@rolldown/binding-freebsd-x64": {
-            "version": "1.0.0-rc.10",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.10.tgz",
-            "integrity": "sha512-XZRXHdTa+4ME1MuDVp021+doQ+z6Ei4CCFmNc5/sKbqb8YmkiJdj8QKlV3rCI0AJtAeSB5n0WGPuJWNL9p/L2w==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+            "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
             "cpu": [
                 "x64"
             ],
@@ -1027,9 +969,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-            "version": "1.0.0-rc.10",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.10.tgz",
-            "integrity": "sha512-R0SQMRluISSLzFE20sPWYHVmJdDQnRyc/FzSCN72BqQmh2SOZUFG+N3/vBZpR4C6WpEUVYJLrYUXaj43sJsNLA==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+            "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
             "cpu": [
                 "arm"
             ],
@@ -1044,9 +986,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-arm64-gnu": {
-            "version": "1.0.0-rc.10",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.10.tgz",
-            "integrity": "sha512-Y1reMrV/o+cwpduYhJuOE3OMKx32RMYCidf14y+HssARRmhDuWXJ4yVguDg2R/8SyyGNo+auzz64LnPK9Hq6jg==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+            "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
             "cpu": [
                 "arm64"
             ],
@@ -1061,9 +1003,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-arm64-musl": {
-            "version": "1.0.0-rc.10",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.10.tgz",
-            "integrity": "sha512-vELN+HNb2IzuzSBUOD4NHmP9yrGwl1DVM29wlQvx1OLSclL0NgVWnVDKl/8tEks79EFek/kebQKnNJkIAA4W2g==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+            "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
             "cpu": [
                 "arm64"
             ],
@@ -1078,9 +1020,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-            "version": "1.0.0-rc.10",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.10.tgz",
-            "integrity": "sha512-ZqrufYTgzxbHwpqOjzSsb0UV/aV2TFIY5rP8HdsiPTv/CuAgCRjM6s9cYFwQ4CNH+hf9Y4erHW1GjZuZ7WoI7w==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+            "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
             "cpu": [
                 "ppc64"
             ],
@@ -1095,9 +1037,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-s390x-gnu": {
-            "version": "1.0.0-rc.10",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.10.tgz",
-            "integrity": "sha512-gSlmVS1FZJSRicA6IyjoRoKAFK7IIHBs7xJuHRSmjImqk3mPPWbR7RhbnfH2G6bcmMEllCt2vQ/7u9e6bBnByg==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+            "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
             "cpu": [
                 "s390x"
             ],
@@ -1112,9 +1054,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-x64-gnu": {
-            "version": "1.0.0-rc.10",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.10.tgz",
-            "integrity": "sha512-eOCKUpluKgfObT2pHjztnaWEIbUabWzk3qPZ5PuacuPmr4+JtQG4k2vGTY0H15edaTnicgU428XW/IH6AimcQw==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+            "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
             "cpu": [
                 "x64"
             ],
@@ -1129,9 +1071,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-x64-musl": {
-            "version": "1.0.0-rc.10",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.10.tgz",
-            "integrity": "sha512-Xdf2jQbfQowJnLcgYfD/m0Uu0Qj5OdxKallD78/IPPfzaiaI4KRAwZzHcKQ4ig1gtg1SuzC7jovNiM2TzQsBXA==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+            "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
             "cpu": [
                 "x64"
             ],
@@ -1146,9 +1088,9 @@
             }
         },
         "node_modules/@rolldown/binding-openharmony-arm64": {
-            "version": "1.0.0-rc.10",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.10.tgz",
-            "integrity": "sha512-o1hYe8hLi1EY6jgPFyxQgQ1wcycX+qz8eEbVmot2hFkgUzPxy9+kF0u0NIQBeDq+Mko47AkaFFaChcvZa9UX9Q==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+            "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
             "cpu": [
                 "arm64"
             ],
@@ -1163,9 +1105,9 @@
             }
         },
         "node_modules/@rolldown/binding-wasm32-wasi": {
-            "version": "1.0.0-rc.10",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.10.tgz",
-            "integrity": "sha512-Ugv9o7qYJudqQO5Y5y2N2SOo6S4WiqiNOpuQyoPInnhVzCY+wi/GHltcLHypG9DEUYMB0iTB/huJrpadiAcNcA==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+            "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
             "cpu": [
                 "wasm32"
             ],
@@ -1173,16 +1115,29 @@
             "license": "MIT",
             "optional": true,
             "dependencies": {
-                "@napi-rs/wasm-runtime": "^1.1.1"
+                "@emnapi/core": "1.11.1",
+                "@emnapi/runtime": "1.11.1",
+                "@napi-rs/wasm-runtime": "^1.1.6"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+            "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
             }
         },
         "node_modules/@rolldown/binding-win32-arm64-msvc": {
-            "version": "1.0.0-rc.10",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.10.tgz",
-            "integrity": "sha512-7UODQb4fQUNT/vmgDZBl3XOBAIOutP5R3O/rkxg0aLfEGQ4opbCgU5vOw/scPe4xOqBwL9fw7/RP1vAMZ6QlAQ==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+            "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
             "cpu": [
                 "arm64"
             ],
@@ -1197,9 +1152,9 @@
             }
         },
         "node_modules/@rolldown/binding-win32-x64-msvc": {
-            "version": "1.0.0-rc.10",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.10.tgz",
-            "integrity": "sha512-PYxKHMVHOb5NJuDL53vBUl1VwUjymDcYI6rzpIni0C9+9mTiJedvUxSk7/RPp7OOAm3v+EjgMu9bIy3N6b408w==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+            "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
             "cpu": [
                 "x64"
             ],
@@ -1214,9 +1169,9 @@
             }
         },
         "node_modules/@rolldown/pluginutils": {
-            "version": "1.0.0-rc.10",
-            "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.10.tgz",
-            "integrity": "sha512-UkVDEFk1w3mveXeKgaTuYfKWtPbvgck1dT8TUG3bnccrH0XtLTuAyfCoks4Q/M5ZGToSVJTIQYCzy2g/atAOeg==",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+            "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
             "dev": true,
             "license": "MIT"
         },
@@ -1266,9 +1221,9 @@
             "license": "MIT"
         },
         "node_modules/@tybys/wasm-util": {
-            "version": "0.10.1",
-            "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-            "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+            "version": "0.10.3",
+            "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+            "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
             "dev": true,
             "license": "MIT",
             "optional": true,
@@ -1468,6 +1423,18 @@
                 "node": ">=0.4.0"
             }
         },
+        "node_modules/agent-base": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+            "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+            "license": "MIT",
+            "dependencies": {
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 6.0.0"
+            }
+        },
         "node_modules/ansi-colors": {
             "version": "4.1.3",
             "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
@@ -1647,14 +1614,15 @@
             }
         },
         "node_modules/axios": {
-            "version": "1.13.2",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.2.tgz",
-            "integrity": "sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==",
+            "version": "1.18.1",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
+            "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
             "license": "MIT",
             "dependencies": {
-                "follow-redirects": "^1.15.6",
-                "form-data": "^4.0.4",
-                "proxy-from-env": "^1.1.0"
+                "follow-redirects": "^1.16.0",
+                "form-data": "^4.0.5",
+                "https-proxy-agent": "^5.0.1",
+                "proxy-from-env": "^2.1.0"
             }
         },
         "node_modules/balanced-match": {
@@ -1731,9 +1699,9 @@
             "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="
         },
         "node_modules/brace-expansion": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-            "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+            "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0"
@@ -2650,9 +2618,9 @@
             }
         },
         "node_modules/flat-cache/node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.16",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+            "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0",
@@ -2681,9 +2649,9 @@
             }
         },
         "node_modules/flat-cache/node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
             "license": "ISC",
             "dependencies": {
                 "brace-expansion": "^1.1.7"
@@ -2709,20 +2677,22 @@
             }
         },
         "node_modules/flatted": {
-            "version": "3.3.1",
-            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
-            "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw=="
+            "version": "3.4.3",
+            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.3.tgz",
+            "integrity": "sha512-/zipXxyO6rGvuNGDiULY9MvEGSkb2gaG4GGH4ygMi0ZZzyMHdUZBmntJmx5x1G2VuPytCwGN4xsJP6cw+sK+vQ==",
+            "license": "ISC"
         },
         "node_modules/follow-redirects": {
-            "version": "1.15.6",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
-            "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
+            "version": "1.16.0",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+            "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
             "funding": [
                 {
                     "type": "individual",
                     "url": "https://github.com/sponsors/RubenVerborgh"
                 }
             ],
+            "license": "MIT",
             "engines": {
                 "node": ">=4.0"
             },
@@ -2756,16 +2726,16 @@
             }
         },
         "node_modules/form-data": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-            "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+            "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
             "license": "MIT",
             "dependencies": {
                 "asynckit": "^0.4.0",
                 "combined-stream": "^1.0.8",
                 "es-set-tostringtag": "^2.1.0",
-                "hasown": "^2.0.2",
-                "mime-types": "^2.1.12"
+                "hasown": "^2.0.4",
+                "mime-types": "^2.1.35"
             },
             "engines": {
                 "node": ">= 6"
@@ -2908,9 +2878,11 @@
             }
         },
         "node_modules/glob": {
-            "version": "10.4.3",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.3.tgz",
-            "integrity": "sha512-Q38SGlYRpVtDBPSWEylRyctn7uDeTp4NQERTLiCT1FqA9JXPYWqAVmQU6qh4r/zMM5ehxTcbaO8EjhWnvEhmyg==",
+            "version": "10.5.0",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+            "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+            "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+            "license": "ISC",
             "dependencies": {
                 "foreground-child": "^3.1.0",
                 "jackspeak": "^3.1.2",
@@ -2921,9 +2893,6 @@
             },
             "bin": {
                 "glob": "dist/esm/bin.mjs"
-            },
-            "engines": {
-                "node": ">=18"
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
@@ -3044,9 +3013,10 @@
             }
         },
         "node_modules/hasown": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-            "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+            "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+            "license": "MIT",
             "dependencies": {
                 "function-bind": "^1.1.2"
             },
@@ -3175,6 +3145,19 @@
                 "node": ">= 0.8"
             }
         },
+        "node_modules/https-proxy-agent": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+            "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+            "license": "MIT",
+            "dependencies": {
+                "agent-base": "6",
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
         "node_modules/image-size": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.2.1.tgz",
@@ -3191,10 +3174,11 @@
             }
         },
         "node_modules/immutable": {
-            "version": "4.3.6",
-            "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.6.tgz",
-            "integrity": "sha512-Ju0+lEMyzMVZarkTn/gqRpdqd5dOPaz1mCZ0SH3JV6iFw81PldE/PEB1hWVEA288HPt4WXW8O7AWxB10M+03QQ==",
-            "dev": true
+            "version": "4.3.9",
+            "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.9.tgz",
+            "integrity": "sha512-ObHy4YN7ycwZOUCLI1/6svfyAFu7vL8RhAvVu/bh/RZW9EPlOyDaQ9jDQWCtdqzaXUjgXZCW1migtHE7YI7UGQ==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/inflight": {
             "version": "1.0.6",
@@ -3569,9 +3553,10 @@
             }
         },
         "node_modules/js-yaml": {
-            "version": "3.14.1",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-            "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+            "version": "3.15.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+            "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+            "license": "MIT",
             "dependencies": {
                 "argparse": "^1.0.7",
                 "esprima": "^4.0.0"
@@ -4051,17 +4036,28 @@
             }
         },
         "node_modules/linkify-it": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
-            "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
+            "integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/puzrin"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/markdown-it"
+                }
+            ],
+            "license": "MIT",
             "dependencies": {
                 "uc.micro": "^2.0.0"
             }
         },
         "node_modules/liquidjs": {
-            "version": "10.24.0",
-            "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.24.0.tgz",
-            "integrity": "sha512-TAUNAdgwaAXjjcUFuYVJm9kOVH7zc0mTKxsG9t9Lu4qdWjB2BEblyVIYpjWcmJLMGgiYqnGNJjpNMHx0gp/46A==",
+            "version": "10.27.2",
+            "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.27.2.tgz",
+            "integrity": "sha512-kvknfAEtOHjHkAAv7GxLEJh8ghpMQm3Fc4uWVyF7hERSTsSRsdC7saWs0p5aDG7GDcWsu5o+T4232O+8KZO55w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4144,14 +4140,24 @@
             }
         },
         "node_modules/markdown-it": {
-            "version": "14.1.1",
-            "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
-            "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
+            "version": "14.3.0",
+            "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.3.0.tgz",
+            "integrity": "sha512-RCEsPjR+sr0x+AuYp601tKTkgFG4YEPLCzHST3cQ/fhlJkqAkz1L2/Qbp1j9qw5SBwQHFBoW8+hoN5xssOF0Tw==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/puzrin"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/markdown-it"
+                }
+            ],
             "license": "MIT",
             "dependencies": {
                 "argparse": "^2.0.1",
-                "entities": "^4.4.0",
-                "linkify-it": "^5.0.0",
+                "entities": "^4.5.0",
+                "linkify-it": "^5.0.2",
                 "mdurl": "^2.0.0",
                 "punycode.js": "^2.3.1",
                 "uc.micro": "^2.1.0"
@@ -4252,9 +4258,9 @@
             }
         },
         "node_modules/maximatch/node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.16",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+            "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4263,9 +4269,9 @@
             }
         },
         "node_modules/maximatch/node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -4333,11 +4339,12 @@
             }
         },
         "node_modules/minimatch": {
-            "version": "9.0.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-            "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+            "version": "9.0.9",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+            "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+            "license": "ISC",
             "dependencies": {
-                "brace-expansion": "^2.0.1"
+                "brace-expansion": "^2.0.2"
             },
             "engines": {
                 "node": ">=16 || 14 >=14.17"
@@ -4387,9 +4394,9 @@
             "license": "MIT"
         },
         "node_modules/nanoid": {
-            "version": "3.3.11",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-            "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+            "version": "3.3.16",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+            "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
             "dev": true,
             "funding": [
                 {
@@ -4521,9 +4528,9 @@
             }
         },
         "node_modules/npm-run-all/node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.16",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+            "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0",
@@ -4589,9 +4596,10 @@
             }
         },
         "node_modules/npm-run-all/node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+            "license": "ISC",
             "dependencies": {
                 "brace-expansion": "^1.1.7"
             },
@@ -5030,9 +5038,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.5.8",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-            "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+            "version": "8.5.23",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+            "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
             "dev": true,
             "funding": [
                 {
@@ -5050,7 +5058,7 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "nanoid": "^3.3.11",
+                "nanoid": "^3.3.16",
                 "picocolors": "^1.1.1",
                 "source-map-js": "^1.2.1"
             },
@@ -5192,9 +5200,13 @@
             }
         },
         "node_modules/proxy-from-env": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-            "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+            "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            }
         },
         "node_modules/prr": {
             "version": "1.0.1",
@@ -5347,9 +5359,9 @@
             }
         },
         "node_modules/rimraf/node_modules/minimatch": {
-            "version": "8.0.4",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-8.0.4.tgz",
-            "integrity": "sha512-W0Wvr9HyFXZRGIDgCicunpQ299OKXs9RgZfaukz4qAW/pJhcpUfupc9c+OObPOFueNy8VSrZgEmDtk6Kh4WzDA==",
+            "version": "8.0.7",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-8.0.7.tgz",
+            "integrity": "sha512-V+1uQNdzybxa14e/p00HZnQNNcTjnRJjDxg2V8wtkjFctq4M7hXFws4oekyTP0Jebeq7QYtpFyOeBAjc88zvYg==",
             "license": "ISC",
             "dependencies": {
                 "brace-expansion": "^2.0.1"
@@ -5371,14 +5383,14 @@
             }
         },
         "node_modules/rolldown": {
-            "version": "1.0.0-rc.10",
-            "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.10.tgz",
-            "integrity": "sha512-q7j6vvarRFmKpgJUT8HCAUljkgzEp4LAhPlJUvQhA5LA1SUL36s5QCysMutErzL3EbNOZOkoziSx9iZC4FddKA==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+            "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@oxc-project/types": "=0.120.0",
-                "@rolldown/pluginutils": "1.0.0-rc.10"
+                "@oxc-project/types": "=0.139.0",
+                "@rolldown/pluginutils": "^1.0.0"
             },
             "bin": {
                 "rolldown": "bin/cli.mjs"
@@ -5387,21 +5399,21 @@
                 "node": "^20.19.0 || >=22.12.0"
             },
             "optionalDependencies": {
-                "@rolldown/binding-android-arm64": "1.0.0-rc.10",
-                "@rolldown/binding-darwin-arm64": "1.0.0-rc.10",
-                "@rolldown/binding-darwin-x64": "1.0.0-rc.10",
-                "@rolldown/binding-freebsd-x64": "1.0.0-rc.10",
-                "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.10",
-                "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.10",
-                "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.10",
-                "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.10",
-                "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.10",
-                "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.10",
-                "@rolldown/binding-linux-x64-musl": "1.0.0-rc.10",
-                "@rolldown/binding-openharmony-arm64": "1.0.0-rc.10",
-                "@rolldown/binding-wasm32-wasi": "1.0.0-rc.10",
-                "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.10",
-                "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.10"
+                "@rolldown/binding-android-arm64": "1.1.5",
+                "@rolldown/binding-darwin-arm64": "1.1.5",
+                "@rolldown/binding-darwin-x64": "1.1.5",
+                "@rolldown/binding-freebsd-x64": "1.1.5",
+                "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+                "@rolldown/binding-linux-arm64-gnu": "1.1.5",
+                "@rolldown/binding-linux-arm64-musl": "1.1.5",
+                "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+                "@rolldown/binding-linux-s390x-gnu": "1.1.5",
+                "@rolldown/binding-linux-x64-gnu": "1.1.5",
+                "@rolldown/binding-linux-x64-musl": "1.1.5",
+                "@rolldown/binding-openharmony-arm64": "1.1.5",
+                "@rolldown/binding-wasm32-wasi": "1.1.5",
+                "@rolldown/binding-win32-arm64-msvc": "1.1.5",
+                "@rolldown/binding-win32-x64-msvc": "1.1.5"
             }
         },
         "node_modules/safe-array-concat": {
@@ -5585,42 +5597,42 @@
             "license": "ISC"
         },
         "node_modules/sharp": {
-            "version": "0.33.4",
-            "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.33.4.tgz",
-            "integrity": "sha512-7i/dt5kGl7qR4gwPRD2biwD2/SvBn3O04J77XKFgL2OnZtQw+AG9wnuS/csmu80nPRHLYE9E41fyEiG8nhH6/Q==",
+            "version": "0.33.5",
+            "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.33.5.tgz",
+            "integrity": "sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==",
             "hasInstallScript": true,
+            "license": "Apache-2.0",
             "dependencies": {
                 "color": "^4.2.3",
                 "detect-libc": "^2.0.3",
-                "semver": "^7.6.0"
+                "semver": "^7.6.3"
             },
             "engines": {
-                "libvips": ">=8.15.2",
                 "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
             },
             "funding": {
                 "url": "https://opencollective.com/libvips"
             },
             "optionalDependencies": {
-                "@img/sharp-darwin-arm64": "0.33.4",
-                "@img/sharp-darwin-x64": "0.33.4",
-                "@img/sharp-libvips-darwin-arm64": "1.0.2",
-                "@img/sharp-libvips-darwin-x64": "1.0.2",
-                "@img/sharp-libvips-linux-arm": "1.0.2",
-                "@img/sharp-libvips-linux-arm64": "1.0.2",
-                "@img/sharp-libvips-linux-s390x": "1.0.2",
-                "@img/sharp-libvips-linux-x64": "1.0.2",
-                "@img/sharp-libvips-linuxmusl-arm64": "1.0.2",
-                "@img/sharp-libvips-linuxmusl-x64": "1.0.2",
-                "@img/sharp-linux-arm": "0.33.4",
-                "@img/sharp-linux-arm64": "0.33.4",
-                "@img/sharp-linux-s390x": "0.33.4",
-                "@img/sharp-linux-x64": "0.33.4",
-                "@img/sharp-linuxmusl-arm64": "0.33.4",
-                "@img/sharp-linuxmusl-x64": "0.33.4",
-                "@img/sharp-wasm32": "0.33.4",
-                "@img/sharp-win32-ia32": "0.33.4",
-                "@img/sharp-win32-x64": "0.33.4"
+                "@img/sharp-darwin-arm64": "0.33.5",
+                "@img/sharp-darwin-x64": "0.33.5",
+                "@img/sharp-libvips-darwin-arm64": "1.0.4",
+                "@img/sharp-libvips-darwin-x64": "1.0.4",
+                "@img/sharp-libvips-linux-arm": "1.0.5",
+                "@img/sharp-libvips-linux-arm64": "1.0.4",
+                "@img/sharp-libvips-linux-s390x": "1.0.4",
+                "@img/sharp-libvips-linux-x64": "1.0.4",
+                "@img/sharp-libvips-linuxmusl-arm64": "1.0.4",
+                "@img/sharp-libvips-linuxmusl-x64": "1.0.4",
+                "@img/sharp-linux-arm": "0.33.5",
+                "@img/sharp-linux-arm64": "0.33.5",
+                "@img/sharp-linux-s390x": "0.33.5",
+                "@img/sharp-linux-x64": "0.33.5",
+                "@img/sharp-linuxmusl-arm64": "0.33.5",
+                "@img/sharp-linuxmusl-x64": "0.33.5",
+                "@img/sharp-wasm32": "0.33.5",
+                "@img/sharp-win32-ia32": "0.33.5",
+                "@img/sharp-win32-x64": "0.33.5"
             }
         },
         "node_modules/shebang-command": {
@@ -5643,9 +5655,13 @@
             }
         },
         "node_modules/shell-quote": {
-            "version": "1.8.1",
-            "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.1.tgz",
-            "integrity": "sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA==",
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.10.0.tgz",
+            "integrity": "sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
@@ -6064,14 +6080,14 @@
             }
         },
         "node_modules/tinyglobby": {
-            "version": "0.2.15",
-            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-            "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+            "version": "0.2.17",
+            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+            "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "fdir": "^6.5.0",
-                "picomatch": "^4.0.3"
+                "picomatch": "^4.0.4"
             },
             "engines": {
                 "node": ">=12.0.0"
@@ -6099,9 +6115,9 @@
             }
         },
         "node_modules/tinyglobby/node_modules/picomatch": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-            "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+            "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -6241,7 +6257,8 @@
         "node_modules/uc.micro": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
-            "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A=="
+            "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+            "license": "MIT"
         },
         "node_modules/ucfirst": {
             "version": "1.0.0",
@@ -6297,17 +6314,17 @@
             }
         },
         "node_modules/vite": {
-            "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.1.tgz",
-            "integrity": "sha512-wt+Z2qIhfFt85uiyRt5LPU4oVEJBXj8hZNWKeqFG4gRG/0RaRGJ7njQCwzFVjO+v4+Ipmf5CY7VdmZRAYYBPHw==",
+            "version": "8.1.5",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+            "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "lightningcss": "^1.32.0",
-                "picomatch": "^4.0.3",
-                "postcss": "^8.5.8",
-                "rolldown": "1.0.0-rc.10",
-                "tinyglobby": "^0.2.15"
+                "picomatch": "^4.0.5",
+                "postcss": "^8.5.17",
+                "rolldown": "~1.1.5",
+                "tinyglobby": "^0.2.17"
             },
             "bin": {
                 "vite": "bin/vite.js"
@@ -6323,8 +6340,8 @@
             },
             "peerDependencies": {
                 "@types/node": "^20.19.0 || >=22.12.0",
-                "@vitejs/devtools": "^0.1.0",
-                "esbuild": "^0.27.0",
+                "@vitejs/devtools": "^0.3.0",
+                "esbuild": "^0.27.0 || ^0.28.0",
                 "jiti": ">=1.21.0",
                 "less": "^4.0.0",
                 "sass": "^1.70.0",
@@ -6375,9 +6392,9 @@
             }
         },
         "node_modules/vite/node_modules/picomatch": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-            "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+            "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -6470,9 +6487,9 @@
             }
         },
         "node_modules/vitest/node_modules/picomatch": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-            "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+            "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -6769,9 +6786,9 @@
             "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
         },
         "node_modules/ws": {
-            "version": "8.18.3",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-            "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+            "version": "8.21.1",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+            "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
             "dev": true,
             "license": "MIT",
             "engines": {


### PR DESCRIPTION
Resolves all 7 open Dependabot alerts on the default branch — `form-data` (critical, unsafe boundary randomness), `axios` ×2 (SSRF), `image-size` (DoS), `cross-spawn` ×2 (ReDoS), `brace-expansion` (low ReDoS) — plus newer advisories npm audit flags locally (`shell-quote`, `vite`, `ws`). All fixes are semver-compatible transitive bumps; the change is lockfile-only.

Verified: 265 tests pass, full Eleventy build of the QA garden succeeds.

Not addressed (no patched upgrade path without swapping parent dependencies): a cluster of old transitive advisories under `eleventy-plugin-gen-favicons`, `@11ty/eleventy-img`/`eleventy-fetch`, `npm-run-all`, `rimraf`, and `glob` (old `minimatch`/`brace-expansion` 1.x majors). npm's only suggestion for these is a breaking parent downgrade, so they need deliberate dependency upgrades rather than an audit fix — happy to take that on as a follow-up if you want.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TFUucReuWzHi8VCKMovneB