### PR TITLE
perf: cut image-heavy build times ~38% and make image work observable

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -35,7 +35,22 @@ const { basesPlugin } = require("./src/helpers/basesPlugin");
 
 const Image = require("@11ty/eleventy-img");
 const { isDecodableImage } = require("./src/helpers/imageFormat.js");
-function transformImage(src, cls, alt, sizes, widths = ["500", "700", "auto"]) {
+
+// Build containers have few CPUs and little memory; the default queue
+// concurrency of 10 holds ~10 decoded images in memory at once without
+// finishing any faster. Sharp already parallelizes within each job.
+Image.concurrency = 2;
+
+// Image generation is started fire-and-forget during transforms (the markup
+// only needs statsSync), but every pending job is awaited in the
+// eleventy.after hook below so the build doesn't linger — or get killed —
+// doing invisible work after Eleventy reports completion.
+const pendingImageJobs = [];
+
+// Note: fillPictureSourceSets only references the first two widths; the
+// full-size original is served via the <img src> fallback, so a full
+// resolution "auto" rendition would never be referenced by the markup.
+function transformImage(src, cls, alt, sizes, widths = ["500", "700"]) {
   let options = {
     widths: widths,
     formats: ["webp", "jpeg"],
@@ -43,12 +58,13 @@ function transformImage(src, cls, alt, sizes, widths = ["500", "700", "auto"]) {
     urlPath: "/img/optimized",
   };
 
-  // Generate images; async, but we don't wait for it. A rejection here
-  // (e.g. a corrupt file) must not become an unhandled rejection, which
-  // would fail the whole build.
-  Image(src, options).catch((err) => {
-    console.warn(`[image] Skipping optimization of ${src}: ${err.message}`);
-  });
+  // A rejection here (e.g. a corrupt file) must not become an unhandled
+  // rejection, which would fail the whole build.
+  pendingImageJobs.push(
+    Image(src, options).catch((err) => {
+      console.warn(`[image] Skipping optimization of ${src}: ${err.message}`);
+    })
+  );
   let metadata = Image.statsSync(src, options);
   return metadata;
 }
@@ -736,6 +752,14 @@ module.exports = function(eleventyConfig) {
   eleventyConfig.addPassthroughCopy({ "src/site/logo.*": "/" });
   eleventyConfig.on("eleventy.before", () => {
     normalizeFavicon(FAVICON_SOURCE, FAVICON_NORMALIZED);
+  });
+  eleventyConfig.on("eleventy.after", async () => {
+    if (pendingImageJobs.length > 0) {
+      console.log(`[image] Waiting for ${pendingImageJobs.length} image optimization jobs...`);
+      await Promise.all(pendingImageJobs);
+      console.log(`[image] Image optimization complete`);
+      pendingImageJobs.length = 0;
+    }
   });
   eleventyConfig.addWatchTarget(FAVICON_SOURCE);
   eleventyConfig.addPlugin(faviconsPlugin, { outputDir: "dist" });

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
         "dev": "npm-run-all get-theme build:sass --parallel watch:*",
         "watch:sass": "sass --watch src/site/styles:dist/styles",
         "watch:eleventy": "cross-env ELEVENTY_ENV=dev eleventy --serve",
-        "build:eleventy": "cross-env ELEVENTY_ENV=prod NODE_OPTIONS=--max-old-space-size=4096 eleventy",
+        "build:eleventy": "cross-env ELEVENTY_ENV=prod UV_THREADPOOL_SIZE=16 NODE_OPTIONS=--max-old-space-size=2048 eleventy",
         "build:sass": "sass src/site/styles:dist/styles --style compressed",
         "get-theme": "node src/site/get-theme.js",
         "build": "npm-run-all get-theme build:*",


### PR DESCRIPTION
Three build-performance fixes, verified against a replica of a hosted builder environment (node:22-alpine, 4Gi, 2 vCPU) on a 210-page garden with 194MB of images (baseline 210s -> 131s):

- Drop the full-resolution "auto" rendition from eleventy-img. fillPictureSourceSets only ever references the first two widths and the <img src> fallback serves the original file, so the full-size webp/jpeg re-encodes (the most expensive sharp work by far) were generated but never referenced by any markup.

- Set UV_THREADPOOL_SIZE=16 for the production build. sharp's async operations run on the libuv threadpool, and at the default size of 4 multi-second image encodes monopolize the pool, serializing all other file I/O (passthrough copies, template reads) behind them. 16 sits on the measured plateau (16 ~= 32); 64 destabilized the build.

- Cap eleventy-img queue concurrency at 2 and await all pending image jobs in an eleventy.after hook. Previously generation was fire-and- forget, so builds kept doing invisible sharp work after Eleventy reported completion - on hosted builders this ran into the job timeout and got killed with no attributable error.

Also lowers --max-old-space-size from 4096 to 2048: peak heap measured far below this, and on 4Gi build containers a 4096MB heap ceiling leaves no headroom for sharp's native memory, turning heap growth into a silent container OOM kill instead of a readable error.
