### PR TITLE
fix: don't let a broken math span abort the whole build

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -170,6 +170,22 @@ module.exports = function(eleventyConfig) {
         skipHtmlTags: { "[-]": ["pre"] },
       },
     })
+    .use(function(md) {
+      // mathjax-full 3.2.2 throws on characters outside its operator
+      // dictionary (e.g. "€") — a stray $...€...$ span in prose would
+      // otherwise abort the entire build. Fall back to the raw text.
+      for (const rule of ["math_inline", "math_block"]) {
+        const original = md.renderer.rules[rule];
+        if (!original) continue;
+        md.renderer.rules[rule] = function(tokens, idx, options, env, self) {
+          try {
+            return original(tokens, idx, options, env, self);
+          } catch (e) {
+            return md.utils.escapeHtml(tokens[idx].content);
+          }
+        };
+      }
+    })
     .use(require("markdown-it-attrs"))
     .use(require("markdown-it-task-checkbox"), {
       disabled: true,


### PR DESCRIPTION
## Problem

mathjax-full 3.2.2 crashes with `Cannot read properties of null (reading '4')` (`BaseConfiguration.js` `Other` handler dereferences a null `getRange()` result) when a `$...$` span contains a character outside its operator dictionary — e.g. `€`. Minimal repro: `$€$`.

Since the template applies markdown-it-mathjax3 to all markdown with `$`/`$` as inline delimiters, two stray dollar signs around such a character in plain prose (currency amounts, OCR'd text) abort the entire 11ty build:

```
[11ty] 1. Having trouble rendering md template ./src/site/notes/... (via TemplateContentRenderError)
[11ty] 2. Cannot read properties of null (reading '4') (via TypeError)
```

Reported by a garden user whose publish failed on a 782 KB OCR'd book note containing the accidental span `$. We are working inside this global ��€$`.

## Fix

Wrap the `math_inline`/`math_block` renderer rules in try/catch and fall back to the escaped raw text, so a bad span degrades gracefully to plain text instead of failing the site.

## Verification

Drove the real `.eleventy.js` (mock eleventyConfig, captured the `setLibrary("md", ...)` lib):

- The exact note that killed the reporter's build now renders (1.3 MB HTML)
- `price is $5 and €$6 total` renders as plain prose instead of crashing
- Legitimate math (`$x^2 + y^2 = z^2$`) still renders as MathJax SVG