### PR TITLE
fix: move Bases engine files to filesToModify so updates reach existing gardens

### DIFF
--- a/plugin-info.json
+++ b/plugin-info.json
@@ -28,18 +28,7 @@
         "vercel.json",
         "netlify.toml",
         "src/site/_includes/layouts/random.njk",
-        "src/site/random.md",
-        "src/helpers/bases-engine/index.js",
-        "src/helpers/bases-engine/exprParser.js",
-        "src/helpers/bases-engine/exprEval.js",
-        "src/helpers/bases-engine/queryEngine.js",
-        "src/helpers/bases-engine/views.js",
-        "src/helpers/bases-engine/imageIndex.js",
-        "src/helpers/bases-engine/noteLinks.js",
-        "src/helpers/bases-engine/noteMetadata.js",
-        "src/helpers/basesPlugin.js",
-        "src/site/_includes/components/basesScript.njk",
-        "src/site/styles/obsidian-bases.scss"
+        "src/site/random.md"
     ],
     "filesToModify": [
         ".eleventy.js",
@@ -83,6 +72,17 @@
         "src/site/get-theme.js",
         "src/site/_data/eleventyComputed.js",
         "src/site/graph.njk",
-        "src/site/search-index.njk"
+        "src/site/search-index.njk",
+        "src/helpers/bases-engine/index.js",
+        "src/helpers/bases-engine/exprParser.js",
+        "src/helpers/bases-engine/exprEval.js",
+        "src/helpers/bases-engine/queryEngine.js",
+        "src/helpers/bases-engine/views.js",
+        "src/helpers/bases-engine/imageIndex.js",
+        "src/helpers/bases-engine/noteLinks.js",
+        "src/helpers/bases-engine/noteMetadata.js",
+        "src/helpers/basesPlugin.js",
+        "src/site/_includes/components/basesScript.njk",
+        "src/site/styles/obsidian-bases.scss"
     ]
 }


### PR DESCRIPTION
Fixes the template-update gap reported in [#816 (comment)](https://github.com/oleeskild/obsidian-digital-garden/issues/816#issuecomment-5318253841).

`TemplateManager.getFilesToAdd` in the plugin skips any `filesToAdd` entry that already exists in the user's repo, so gardens that adopted Bases support at 1.82.0 never received the 1.83.x fixes to `exprEval.js` and friends — users had to copy the files by hand.

This moves all Bases-related files (the eight `bases-engine/` modules, `basesPlugin.js`, `basesScript.njk`, `obsidian-bases.scss`) from `filesToAdd` to `filesToModify`. This is safe for gardens that don't have them yet: `getPathsToModify` queues missing files with an undefined sha, and `addOrUpdateFiles` creates a file when no sha is passed.

These files are engine code, not user-customizable (unlike `custom-style.scss`/`userSetup.js`, which stay in `filesToAdd`), so overwriting on update is the intended behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EDQTKUG4XFSGLwoJLcdk74