### PR TITLE
fix: render date-only properties without a spurious midnight timestamp

### DIFF
--- a/src/helpers/bases-engine/__tests__/views.test.js
+++ b/src/helpers/bases-engine/__tests__/views.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { renderViews } from "../views.js";
+import { renderViews, formatCellValue } from "../views.js";
 import { createImageIndex } from "../imageIndex.js";
 
 // Mock query result helpers
@@ -991,5 +991,39 @@ describe("renderViews", () => {
 				'class="internal-link is-unresolved">Missing Person</a>',
 			);
 		});
+	});
+});
+
+describe("formatCellValue date rendering", () => {
+	const row = { url: "/notes/test/", metadata: {} };
+
+	it("keeps a date-only string date-only in the human-date span", () => {
+		const html = formatCellValue("1707-04-17", "born", row);
+		expect(html).toBe('<span class="human-date" data-date="1707-04-17"></span>');
+	});
+
+	it("keeps time in a datetime string", () => {
+		const html = formatCellValue("2024-01-15T14:30:00Z", "meeting", row);
+		expect(html).toBe(
+			'<span class="human-date" data-date="2024-01-15T14:30:00Z"></span>',
+		);
+	});
+
+	it("renders a UTC-midnight Date (YAML date-only) as a date-only value", () => {
+		// js-yaml parses unquoted `born: 1707-04-17` to a Date at UTC midnight
+		const html = formatCellValue(new Date("1707-04-17T00:00:00.000Z"), "born", row);
+		expect(html).toBe('<span class="human-date" data-date="1707-04-17"></span>');
+	});
+
+	it("renders a local-midnight Date (coerceDate output) as a date-only value", () => {
+		const html = formatCellValue(new Date(2024, 0, 15), "born", row);
+		expect(html).toBe('<span class="human-date" data-date="2024-01-15"></span>');
+	});
+
+	it("keeps full ISO for a Date with a real time component", () => {
+		const html = formatCellValue(new Date("2024-01-15T14:30:00.000Z"), "meeting", row);
+		expect(html).toBe(
+			'<span class="human-date" data-date="2024-01-15T14:30:00.000Z"></span>',
+		);
 	});
 });

--- a/src/helpers/bases-engine/views.js
+++ b/src/helpers/bases-engine/views.js
@@ -82,6 +82,36 @@ function isISODate(str) {
 	return ISO_DATE_REGEX.test(str);
 }
 
+/**
+ * Return the YYYY-MM-DD calendar date for a Date that represents a
+ * date-only value, or null if it has a real time component.
+ * Date-only values reach us as UTC midnight (js-yaml parses unquoted
+ * `born: 1707-04-17` that way) or local midnight (coerceDate in
+ * exprEval builds dates in local time to match Obsidian). Serializing
+ * them with toISOString() would let the client's timezone conversion
+ * shift the displayed day and append a spurious midnight timestamp.
+ */
+function dateOnlyString(date) {
+	if (
+		date.getUTCHours() === 0 &&
+		date.getUTCMinutes() === 0 &&
+		date.getUTCSeconds() === 0 &&
+		date.getUTCMilliseconds() === 0
+	) {
+		return date.toISOString().slice(0, 10);
+	}
+	if (
+		date.getHours() === 0 &&
+		date.getMinutes() === 0 &&
+		date.getSeconds() === 0 &&
+		date.getMilliseconds() === 0
+	) {
+		const pad = (n) => String(n).padStart(2, "0");
+		return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`;
+	}
+	return null;
+}
+
 // --- Helper functions ---
 
 /**
@@ -272,7 +302,8 @@ function formatCellValue(value, column, row) {
 		if (value._basesType === "now") {
 			return '<span class="bases-dynamic-date" data-type="now"></span>';
 		}
-		return `<span class="human-date" data-date="${escapeHtml(value.toISOString())}"></span>`;
+		const dateOnly = dateOnlyString(value);
+		return `<span class="human-date" data-date="${escapeHtml(dateOnly || value.toISOString())}"></span>`;
 	}
 
 	return escapeHtml(String(value));

--- a/src/site/_data/meta.js
+++ b/src/site/_data/meta.js
@@ -63,6 +63,7 @@ module.exports = async (data) => {
 
   let timestampSettings = {
     timestampFormat: process.env.TIMESTAMP_FORMAT || "MMM dd, yyyy h:mm a",
+    dateFormat: process.env.DATE_FORMAT || "MMM dd, yyyy",
     showCreated: process.env.SHOW_CREATED_TIMESTAMP == "true",
     showUpdated: process.env.SHOW_UPDATED_TIMESTAMP == "true",
   };

--- a/src/site/_includes/components/timestamps.njk
+++ b/src/site/_includes/components/timestamps.njk
@@ -1,10 +1,15 @@
 <script src=" https://fastly.jsdelivr.net/npm/luxon@3.2.1/build/global/luxon.min.js "></script>
 <script defer>
   TIMESTAMP_FORMAT = "{{meta.timestampSettings.timestampFormat}}";
+  DATE_FORMAT = "{{meta.timestampSettings.dateFormat}}";
   document.querySelectorAll('.human-date').forEach(function (el) {
     // One malformed date must not abort formatting of the remaining dates
     try {
       date = el.getAttribute('data-date') || el.innerText
+      // A value with no time component (e.g. "1707-04-17") gets the
+      // date-only format — the timestamp format would show it as
+      // "Apr 17, 1707 12:00 AM"
+      format = /^\d{4}-\d{2}-\d{2}$/.test(date.trim()) ? DATE_FORMAT : TIMESTAMP_FORMAT
       parsed_date = luxon.DateTime.fromISO(date)
       if (parsed_date.invalid != null){
         // Date cannot be parsed
@@ -15,7 +20,7 @@
         parsed_date = luxon.DateTime.fromHTTP(date)
       }
       if (parsed_date.invalid == null){
-        el.innerHTML = parsed_date.toFormat(TIMESTAMP_FORMAT);
+        el.innerHTML = parsed_date.toFormat(format);
       }
     } catch (e) {}
   })


### PR DESCRIPTION
Fixes the cosmetic issue reported in [#816 (comment)](https://github.com/oleeskild/obsidian-digital-garden/issues/816#issuecomment-5318253841): a date-only property like `born: 1707-04-17` rendered as **"Apr 17, 1707 12:00 AM"**.

## Root cause
`timestamps.njk` formats every `.human-date` span with the single site-wide `TIMESTAMP_FORMAT` (default `MMM dd, yyyy h:mm a`), so Luxon parses a date-only value as midnight and the time tokens print it. There was no date-only rendering path.

## Fix
- **timestamps.njk**: values matching `YYYY-MM-DD` (no time component) are formatted with a new date-only format instead — `DATE_FORMAT` env setting, default `MMM dd, yyyy` (added to `meta.js`). `born: 1707-04-17` now renders as **"Apr 17, 1707"**; datetimes are unchanged.
- **views.js**: a `Date` object representing a date-only value (js-yaml parses unquoted YAML dates to UTC midnight; `coerceDate` builds local midnight) was serialized with `toISOString()`, so the client's timezone conversion could both re-attach a time and shift the displayed **day** for viewers west of UTC. Midnight-exact Dates now serialize as plain `YYYY-MM-DD`. Trade-off: a genuine datetime that is exactly midnight renders date-only.

Covered by 5 new tests in `views.test.js` (351 pass total).

## Update propagation note
`timestamps.njk` and `meta.js` are already in `filesToModify`, so the main fix reaches existing gardens on the next template update. 

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EDQTKUG4XFSGLwoJLcdk74