### PR TITLE
fix: raise eleventy heap cap from 2048 to 3072 MB

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
         "dev": "npm-run-all get-theme build:sass --parallel watch:*",
         "watch:sass": "sass --watch src/site/styles:dist/styles",
         "watch:eleventy": "cross-env ELEVENTY_ENV=dev eleventy --serve",
-        "build:eleventy": "cross-env ELEVENTY_ENV=prod UV_THREADPOOL_SIZE=16 NODE_OPTIONS=--max-old-space-size=2048 eleventy",
+        "build:eleventy": "cross-env ELEVENTY_ENV=prod UV_THREADPOOL_SIZE=16 NODE_OPTIONS=--max-old-space-size=3072 eleventy",
         "build:sass": "sass src/site/styles:dist/styles --style compressed",
         "get-theme": "node src/site/get-theme.js",
         "build": "npm-run-all get-theme build:*",


### PR DESCRIPTION
## Why

#397 lowered `--max-old-space-size` from 4096 to 2048, tuned on a 210-page garden. Large text-heavy gardens (~1,100+ notes, ~10 min builds) now die mid-build with a V8 `allocation failure` at ~2 GB heap, while a 4Gi build container (like vercel has) still has half its memory free. First hit: a hosted garden that had built fine on 4096.
## Change

One line in `package.json`: `--max-old-space-size=2048` → `3072`.

3072 clears the gardens we've seen fail (heap peaked right at the 2 GB cap) and still leaves ~1 GB on a 4Gi container for sharp's native memory, which was #397's reason for lowering it.
