### PR TITLE
Fix node ID 0 not being clickable on graph

### DIFF
--- a/src/site/_includes/components/graphScript.njk
+++ b/src/site/_includes/components/graphScript.njk
@@ -305,7 +305,7 @@ function renderGraph(graphData, containerId, isFullScreen) {
         d3Drag()
             .container(() => app.view)
             .subject(() => {
-                if (!hoveredNodeId) return null;
+                if (hoveredNodeId === null) return null;
                 const node = nodes.find(n => n.id === hoveredNodeId);
                 if (!node) return null;
                 return {


### PR DESCRIPTION
seems to be a 0 is falsy JavaScript bug.

Node ID 0 was treated as if no node was hovered. Fix checks explicitly for `null` instead.