### PR TITLE
feat: render Excalidraw inline notes as content previews

### DIFF
--- a/plugin-info.json
+++ b/plugin-info.json
@@ -61,6 +61,7 @@
         "src/site/_includes/components/navbar.njk",
         "src/site/_includes/components/calloutScript.njk",
         "src/site/_includes/components/canvasScript.njk",
+        "src/site/_includes/components/excalidrawScript.njk",
         "src/site/_includes/components/lucideIcons.njk",
         "src/site/_includes/components/pluginSlot.njk",
         "src/site/_includes/components/pluginRegion.njk",

--- a/src/site/_includes/components/excalidrawScript.njk
+++ b/src/site/_includes/components/excalidrawScript.njk
@@ -1,0 +1,56 @@
+<style>
+  .excalidraw-svg .excalidraw-embedded-note-content {
+    width: 100%;
+    height: 100%;
+    overflow-y: auto;
+    /* Same theming as the link preview tooltip, so the note content is
+       styled coherently with the rest of the site */
+    background: var(--background-primary);
+    color: var(--text-normal);
+    padding: 0.5em 1em;
+    font-size: 0.8em;
+    border: 1px solid var(--background-modifier-border, #e3e3e3);
+    border-radius: 4px;
+    box-sizing: border-box;
+    unicode-bidi: plaintext;
+  }
+</style>
+<script>
+  // Embedded notes inside Excalidraw drawings are published as same-origin
+  // iframes of the note's page. Like the link preview tooltip, extract just
+  // the note content from the loaded page and show that instead of the
+  // full framed page with all its UI.
+  window.addEventListener("load", function () {
+    document
+      .querySelectorAll("iframe.excalidraw-embedded-note")
+      .forEach(function (frame) {
+        function showNoteContent() {
+          var doc;
+          try {
+            doc = frame.contentDocument;
+          } catch (e) {
+            return;
+          }
+          if (!doc) return;
+
+          var content = doc.querySelector(".content");
+          if (!content) return;
+
+          var noteDiv = document.createElement("div");
+          noteDiv.className = "excalidraw-embedded-note-content";
+          noteDiv.innerHTML = content.innerHTML;
+          frame.parentNode.replaceChild(noteDiv, frame);
+        }
+
+        if (
+          frame.contentDocument &&
+          frame.contentDocument.readyState === "complete" &&
+          frame.contentDocument.querySelector(".content")
+        ) {
+          showNoteContent();
+        } else {
+          frame.addEventListener("load", showNoteContent);
+        }
+      });
+  });
+</script>

--- a/src/site/_includes/layouts/index.njk
+++ b/src/site/_includes/layouts/index.njk
@@ -78,5 +78,6 @@
     {% endfor %}
     {%include "components/lucideIcons.njk"%}
     {%include "components/basesScript.njk"%}
+    {%include "components/excalidrawScript.njk"%}
     </body>
   </html>

--- a/src/site/_includes/layouts/note.njk
+++ b/src/site/_includes/layouts/note.njk
@@ -86,5 +86,6 @@ permalink: "notes/{{ page.fileSlug | slugify }}/"
       {%include "components/canvasScript.njk"%}
     {% endif %}
     {% include "components/basesScript.njk" %}
+    {% include "components/excalidrawScript.njk" %}
   </body>
 </html>


### PR DESCRIPTION
## Summary

Companion to oleeskild/obsidian-digital-garden#825 (SVG-at-publish-time Excalidraw export). Inline embedded notes inside drawings arrive as same-origin iframes with the class `excalidraw-embedded-note`, pointing at the note's garden page. Left as-is, they'd display the full framed page — navbar, file tree, sidebar and all.

This adds `excalidrawScript.njk`, which does the same trick as the link preview tooltip: once the iframe loads, it extracts the page's `.content` element and swaps the iframe for a content card styled with the site's theme variables (`--background-primary`, `--text-normal`), so the embedded note shows just its content, coherently themed.

- New component `src/site/_includes/components/excalidrawScript.njk`
- Included from both `note.njk` and `index.njk` (no-op on pages without drawings)
- Added to `filesToModify` in `plugin-info.json` so existing gardens receive it on template update

### Test plan

Built the site locally from the plugin's dev-vault export and verified in headless Chromium: the iframe is replaced by a card containing only the embedded note's content, long notes scroll within the card, and pages without drawings are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016yAt6QwTycJ4aXRSsR6VAs