### PR TITLE
perf: 5x faster builds — build-once graph/filetree, cached minification and slugify

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,4 +1,3 @@
-const slugify = require("@sindresorhus/slugify");
 const markdownIt = require("markdown-it");
 const fs = require("fs");
 const matter = require("gray-matter");
@@ -28,7 +27,96 @@ const { parse } = require("node-html-parser");
 const htmlMinifier = require("html-minifier-terser");
 const pluginRss = require("@11ty/eleventy-plugin-rss");
 
-const { headerToId, namedHeadingsFilter } = require("./src/helpers/utils");
+// Minifying inline JS/CSS is the single most expensive part of the build, and
+// nearly every page carries the same inline scripts and styles from the
+// layouts. These cached wrappers mirror html-minifier-terser's built-in
+// terser/clean-css invocations (same options, same error fallbacks) but only
+// pay for each distinct input once per process. Resolve the exact terser and
+// clean-css instances html-minifier-terser itself uses.
+const htmlMinifierRequire = require("module").createRequire(
+  require.resolve("html-minifier-terser")
+);
+const terser = htmlMinifierRequire("terser");
+const CleanCSS = htmlMinifierRequire("clean-css");
+
+const MINIFY_CACHE_MAX = 2000;
+const minifyJsCache = new Map();
+const minifyCssCache = new Map();
+
+function cachePut(cache, key, value) {
+  if (cache.size >= MINIFY_CACHE_MAX) {
+    cache.clear();
+  }
+  cache.set(key, value);
+}
+
+async function cachedMinifyJS(text, inline) {
+  const key = `${inline ? 1 : 0}:${text}`;
+  if (minifyJsCache.has(key)) {
+    return minifyJsCache.get(key);
+  }
+  let result;
+  try {
+    const start = text.match(/^\s*<!--.*/);
+    const code = start
+      ? text.slice(start[0].length).replace(/\n\s*-->\s*$/, "")
+      : text;
+    const minified = await terser.minify(code, {
+      parse: { bare_returns: inline },
+    });
+    result = minified.code.replace(/;$/, "");
+  } catch {
+    result = text;
+  }
+  cachePut(minifyJsCache, key, result);
+  return result;
+}
+
+function wrapCSS(text, type) {
+  switch (type) {
+    case "inline":
+      return `*{${text}}`;
+    case "media":
+      return `@media ${text}{a{top:0}}`;
+    default:
+      return text;
+  }
+}
+
+function unwrapCSS(text, type) {
+  let matches;
+  switch (type) {
+    case "inline":
+      matches = text.match(/^\*\{([\s\S]*)\}$/);
+      break;
+    case "media":
+      matches = text.match(/^@media ([\s\S]*?)\s*{[\s\S]*}$/);
+      break;
+  }
+  return matches ? matches[1] : text;
+}
+
+function cachedMinifyCSS(text, type) {
+  const key = `${type || ""}:${text}`;
+  if (minifyCssCache.has(key)) {
+    return minifyCssCache.get(key);
+  }
+  let result;
+  const output = new CleanCSS({}).minify(wrapCSS(text, type));
+  if (output.errors.length > 0) {
+    result = text;
+  } else {
+    result = unwrapCSS(output.styles, type);
+  }
+  cachePut(minifyCssCache, key, result);
+  return result;
+}
+
+const {
+  headerToId,
+  namedHeadingsFilter,
+  cachedSlugify: slugify,
+} = require("./src/helpers/utils");
 const {
   userMarkdownSetup,
   userEleventySetup,
@@ -77,7 +165,24 @@ function getAnchorLink(filePath, linkTitle) {
   return `<a ${Object.keys(attributes).map(key => `${key}="${attributes[key]}"`).join(" ")}>${innerHTML}</a>`;
 }
 
+// Resolving a wikilink target reads and YAML-parses the target note's
+// frontmatter from disk. The same targets are linked from many notes (and the
+// same link is resolved again by the graph/backlink machinery), so cache per
+// (target, title). Cleared in eleventy.before so watch-mode rebuilds see
+// frontmatter edits.
+const anchorAttributesCache = new Map();
+
 function getAnchorAttributes(filePath, linkTitle) {
+  const cacheKey = `${filePath}\x00${linkTitle || ""}`;
+  let cached = anchorAttributesCache.get(cacheKey);
+  if (!cached) {
+    cached = computeAnchorAttributes(filePath, linkTitle);
+    anchorAttributesCache.set(cacheKey, cached);
+  }
+  return cached;
+}
+
+function computeAnchorAttributes(filePath, linkTitle) {
   let fileName = filePath.replaceAll("&amp;", "&");
   let header = "";
   let headerLinkPath = "";
@@ -457,11 +562,12 @@ module.exports = function(eleventyConfig) {
     return str;
   });
 
-  eleventyConfig.addTransform("dataview-js-links", function(str) {
-    if (!isMarkdownPage(this.page.inputPath)) {
-      return str;
-    }
-    const parsed = parse(str);
+  // The dataview-js-links, callout-block, picture and table steps below used
+  // to be four separate transforms, each doing its own full HTML parse and
+  // re-serialize of every page. They are applied in the same order on a
+  // single parsed tree in the combined "obsidian-html" transform after their
+  // helper definitions.
+  function transformDataviewJsLinks(parsed) {
     for (const dataViewJsLink of parsed.querySelectorAll("a[data-href].internal-link")) {
       const notePath = dataViewJsLink.getAttribute("data-href");
       const title = dataViewJsLink.innerHTML;
@@ -471,9 +577,7 @@ module.exports = function(eleventyConfig) {
       }
       dataViewJsLink.innerHTML = innerHTML;
     }
-
-    return str && parsed.innerHTML;
-  });
+  }
 
   // Shared helper to transform callout blockquotes - used by both callout-block transform and canvas-markdown
   const calloutMeta = /\[!([\w-]*)\|?(\s?.*)\](\+|\-){0,1}(\s?.*)/;
@@ -530,14 +634,6 @@ module.exports = function(eleventyConfig) {
     }
   }
 
-  eleventyConfig.addTransform("callout-block", function(str) {
-    if (!isMarkdownPage(this.page.inputPath)) {
-      return str;
-    }
-    const parsed = parse(str);
-    transformCalloutBlockquotes(parsed.querySelectorAll("blockquote"));
-    return str && parsed.innerHTML;
-  });
 
   function fillPictureSourceSets(src, cls, alt, meta, width, imageTag) {
     imageTag.tagName = "picture";
@@ -574,14 +670,10 @@ module.exports = function(eleventyConfig) {
   }
 
 
-  eleventyConfig.addTransform("picture", async function(str) {
-    if (!isMarkdownPage(this.page.inputPath)) {
-      return str;
-    }
+  async function transformPictures(parsed) {
     if (process.env.USE_FULL_RESOLUTION_IMAGES === "true") {
-      return str;
+      return;
     }
-    const parsed = parse(str);
     for (const imageTag of parsed.querySelectorAll(".cm-s-obsidian img")) {
       const src = imageTag.getAttribute("src");
       if (src && src.startsWith("/") && !src.endsWith(".svg")) {
@@ -614,14 +706,9 @@ module.exports = function(eleventyConfig) {
         }
       }
     }
-    return str && parsed.innerHTML;
-  });
+  }
 
-  eleventyConfig.addTransform("table", function(str) {
-    if (!isMarkdownPage(this.page.inputPath)) {
-      return str;
-    }
-    const parsed = parse(str);
+  function transformTables(parsed) {
     for (const t of parsed.querySelectorAll(".cm-s-obsidian > table")) {
       let inner = t.innerHTML;
       t.tagName = "div";
@@ -643,7 +730,18 @@ module.exports = function(eleventyConfig) {
         th.classList.add("table-view-th");
       });
     }
-    return str && parsed.innerHTML;
+  }
+
+  eleventyConfig.addTransform("obsidian-html", async function(str) {
+    if (!str || !isMarkdownPage(this.page.inputPath)) {
+      return str;
+    }
+    const parsed = parse(str);
+    transformDataviewJsLinks(parsed);
+    transformCalloutBlockquotes(parsed.querySelectorAll("blockquote"));
+    await transformPictures(parsed);
+    transformTables(parsed);
+    return parsed.innerHTML;
   });
 
   // Helper function to convert wiki-links in canvas text nodes (same logic as link filter)
@@ -718,14 +816,18 @@ module.exports = function(eleventyConfig) {
       (this.page.outputPath || "").endsWith(".html")
     ) {
       try {
+        // preserveLineBreaks is intentionally off: its trailing-whitespace
+        // regex is quadratic on large text chunks and was one of the biggest
+        // single costs of the whole build. conservativeCollapse still keeps a
+        // whitespace character wherever there was one (a newline renders the
+        // same as a space), so output is visually identical.
         return await htmlMinifier.minify(content, {
           useShortDoctype: true,
           removeComments: true,
           collapseWhitespace: true,
           conservativeCollapse: true,
-          preserveLineBreaks: true,
-          minifyCSS: true,
-          minifyJS: true,
+          minifyCSS: cachedMinifyCSS,
+          minifyJS: cachedMinifyJS,
           keepClosingSlash: true,
         });
       } catch {
@@ -758,6 +860,7 @@ module.exports = function(eleventyConfig) {
   eleventyConfig.addPassthroughCopy({ "src/site/logo.*": "/" });
   eleventyConfig.on("eleventy.before", () => {
     normalizeFavicon(FAVICON_SOURCE, FAVICON_NORMALIZED);
+    anchorAttributesCache.clear();
   });
   eleventyConfig.on("eleventy.after", async () => {
     if (pendingImageJobs.length > 0) {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
         "build:eleventy": "cross-env ELEVENTY_ENV=prod UV_THREADPOOL_SIZE=16 NODE_OPTIONS=--max-old-space-size=3072 eleventy",
         "build:sass": "sass src/site/styles:dist/styles --style compressed",
         "get-theme": "node src/site/get-theme.js",
-        "build": "npm-run-all get-theme build:*",
+        "build": "npm-run-all get-theme --parallel build:*",
         "test": "vitest run"
     },
     "keywords": [],

--- a/src/helpers/filetreeUtils.js
+++ b/src/helpers/filetreeUtils.js
@@ -157,7 +157,31 @@ function assignNested(obj, keyPath, value) {
   obj[keyPath[lastKeyIndex]] = value;
 }
 
+// getFileTree is called from eleventyComputed, i.e. once per rendered page,
+// but its result only depends on the note collection and navigation order.
+// Cache per collection array (fresh each build, so the cache self-invalidates
+// across watch-mode rebuilds); navigationOrder is the inner key since it can
+// in principle differ per data cascade entry.
+const fileTreeCache = new WeakMap();
+
 function getFileTree(data) {
+  const notes = data.collections.note;
+  if (!notes) {
+    return computeFileTree(data);
+  }
+  let byOrder = fileTreeCache.get(notes);
+  if (!byOrder) {
+    byOrder = new Map();
+    fileTreeCache.set(notes, byOrder);
+  }
+  const orderKey = data.navigationOrder || null;
+  if (!byOrder.has(orderKey)) {
+    byOrder.set(orderKey, computeFileTree(data));
+  }
+  return byOrder.get(orderKey);
+}
+
+function computeFileTree(data) {
   const tree = {};
   (data.collections.note || []).forEach((note) => {
     const [meta, folders] = getPermalinkMeta(note);

--- a/src/helpers/linkUtils.js
+++ b/src/helpers/linkUtils.js
@@ -204,7 +204,27 @@ function extractBasesLinks(content, basesNotes) {
   return links;
 }
 
-async function getGraph(data) {
+// getGraph is called from eleventyComputed, i.e. once per rendered page, but
+// its result only depends on the note collection. Recomputing it per page made
+// the build O(notes²). Cache the in-flight promise keyed on the collection
+// array itself: each build (including watch-mode rebuilds) creates a fresh
+// collections array, so the cache self-invalidates and old entries get GC'd.
+const graphCache = new WeakMap();
+
+function getGraph(data) {
+  const notes = data.collections.note;
+  if (!notes) {
+    return computeGraph(data);
+  }
+  let cached = graphCache.get(notes);
+  if (!cached) {
+    cached = computeGraph(data);
+    graphCache.set(notes, cached);
+  }
+  return cached;
+}
+
+async function computeGraph(data) {
   let nodes = {};
   let links = [];
   let stemURLs = {};

--- a/src/helpers/utils.js
+++ b/src/helpers/utils.js
@@ -1,7 +1,25 @@
 const slugify = require("@sindresorhus/slugify");
 
+// slugify rebuilds its transliteration/escape regexes on every call, which
+// makes it one of the most expensive functions in a build (it runs for every
+// heading and every wikilink). The same strings repeat constantly, so memoize.
+const slugifyCache = new Map();
+const SLUGIFY_CACHE_MAX = 50000;
+
+function cachedSlugify(input) {
+    if (slugifyCache.has(input)) {
+        return slugifyCache.get(input);
+    }
+    const result = slugify(input);
+    if (slugifyCache.size >= SLUGIFY_CACHE_MAX) {
+        slugifyCache.clear();
+    }
+    slugifyCache.set(input, result);
+    return result;
+}
+
 function headerToId(heading) {
-    var slugifiedHeader = slugify(heading);
+    var slugifiedHeader = cachedSlugify(heading);
     if(!slugifiedHeader){
         return heading;
     }
@@ -49,3 +67,4 @@ exports.namedHeadingsFilter = function (md, options) {
 }
 
 exports.headerToId = headerToId;
+exports.cachedSlugify = cachedSlugify;


### PR DESCRIPTION
## Summary

Profiling a build of a 300-note garden (CPU profile + Eleventy benchmarks) showed the time going to a handful of hotspots. Fixing them takes the benchmark build from **39s to ~8s (5×)** with no change to the rendered output. The biggest fix is asymptotic, so large gardens gain the most.

### Hotspots fixed

- **`getGraph`/`getFileTree` ran once per rendered page** via `eleventyComputed` — the full graph/backlink/filetree computation over all notes repeated for every page (600+ invocations per build), making the build O(notes²). Both are now computed once per build, cached via a `WeakMap` keyed on the collections array, so watch-mode rebuilds (which create a fresh collections array) self-invalidate.
- **Inline JS/CSS minification** re-ran terser/clean-css on the same layout scripts/styles for every page (~13s of the 39s). The `htmlMinifier` transform now uses cached `minifyJS`/`minifyCSS` wrappers that mirror html-minifier-terser's built-in invocations (same options, same error fallbacks) but pay for each distinct input once.
- **`preserveLineBreaks` dropped** from the minifier options: its trailing-whitespace regex is quadratic on large text chunks (7s alone). With `conservativeCollapse` still on, a newline collapses to a space, which renders identically.
- **`slugify` memoized** — it rebuilds its transliteration regexes on every call and runs for every heading and wikilink (~5s).
- **`getAnchorAttributes` cached** per (target, title) — it re-read and re-YAML-parsed the target note's frontmatter from disk for every wikilink occurrence. Cleared in `eleventy.before` so watch mode sees frontmatter edits.
- **Four HTML transforms merged into one** — `dataview-js-links`, `callout-block`, `picture` and `table` each fully parsed and re-serialized every page; they now share a single parse in one `obsidian-html` transform, applied in the same order.
- **Sass runs in parallel with Eleventy** — stylesheets are only referenced via `<link>` tags, so nothing in the Eleventy build reads the compiled CSS.

## Verification

- Built a 300-note synthetic garden (wikilinks, callouts, tags, headings) with old and new code: output is **byte-identical** modulo the intended newline→space whitespace collapse and the `?v=` build-timestamp cache-buster.
- All **379 tests pass**.
- Watch mode verified: editing a note's permalink updates links to it on other pages (caches invalidate per build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Abe88diopmR9JKQwHfNM5C