### PR TITLE
feat: LOGO_HEIGHT env var to control the site logo size

### DIFF
--- a/src/site/_data/meta.js
+++ b/src/site/_data/meta.js
@@ -15,6 +15,16 @@ module.exports = async (data) => {
     // Use the first match and convert to site-relative path
     logoPath = "/" + logoFiles[0].split("src/site/")[1];
   }
+
+  // Logo height override. A bare number means pixels; any other value must
+  // be a simple CSS length (e.g. "3rem") — anything else is ignored so the
+  // env value can't inject arbitrary CSS.
+  let logoHeight = (process.env.LOGO_HEIGHT || "").trim();
+  if (/^\d+(\.\d+)?$/.test(logoHeight)) {
+    logoHeight += "px";
+  } else if (!/^\d+(\.\d+)?(px|rem|em|%|vh|vw|ch)$/.test(logoHeight)) {
+    logoHeight = "";
+  }
   if (themeStyle) {
     themeStyle = themeStyle.split("site")[1];
   }
@@ -100,6 +110,7 @@ module.exports = async (data) => {
     baseTheme: process.env.BASE_THEME || "dark",
     siteName: process.env.SITE_NAME_HEADER || "Digital Garden",
     siteLogoPath: logoPath,
+    logoHeight,
     mainLanguage: process.env.SITE_MAIN_LANGUAGE || "en",
     siteBaseUrl: baseUrl,
     styleSettingsCss,

--- a/src/site/_includes/components/pageheader.njk
+++ b/src/site/_includes/components/pageheader.njk
@@ -65,5 +65,14 @@
         {{ meta.styleSettingsCss | safe }}
     </style>
 {% endif %}
+{% if meta.logoHeight %}
+    <style>
+        :root {
+            --dg-logo-height: {{ meta.logoHeight }};
+            --dg-logo-height-mobile: {{ meta.logoHeight }};
+            --dg-filetree-logo-height: {{ meta.logoHeight }};
+        }
+    </style>
+{% endif %}
 <style>
 </style>


### PR DESCRIPTION
Adds a `LOGO_HEIGHT` env var so the plugin's new "Logo size" setting can control how large the site logo renders.

- `meta.js` validates and normalizes the value: a bare number becomes pixels (`64` → `64px`), simple CSS lengths (`3rem`, `50%`, …) pass through, and anything else is ignored so the env file can't inject arbitrary CSS.
- `pageheader.njk` emits a `:root` override of `--dg-logo-height`, `--dg-logo-height-mobile` and `--dg-filetree-logo-height` when set.

Unset or invalid values leave the existing 40px default untouched. Verified with an eleventy build: `LOGO_HEIGHT=64` renders `--dg-logo-height:64px` in the built pages.

Companion plugin PR: oleeskild/obsidian-digital-garden (Logo size setting + touched-keys env updates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LYAomPqxuzVV25xjcqgGTs